### PR TITLE
feat: worker daemon skeleton — MQTT + heartbeat (#4)

### DIFF
--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "pydantic>=2.10",
+    "pydantic-settings>=2.7",
     "paho-mqtt>=2.1",
     "click>=8.1",
 ]

--- a/worker/src/ai_swarm_worker/config.py
+++ b/worker/src/ai_swarm_worker/config.py
@@ -1,1 +1,18 @@
-# TODO: implement config loader (Task 4)
+from __future__ import annotations
+
+import os
+import socket
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class WorkerConfig(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="AI_SWARM_", case_sensitive=False)
+
+    worker_id: str = f"{socket.gethostname()}-{os.getpid()}"
+    mqtt_broker_url: str
+    mqtt_username: str
+    mqtt_password: str
+    mqtt_keepalive: int = 60
+    heartbeat_interval: int = 30
+    log_level: str = "INFO"

--- a/worker/src/ai_swarm_worker/heartbeat.py
+++ b/worker/src/ai_swarm_worker/heartbeat.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import UTC, datetime
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class Publishable(Protocol):
+    def publish(self, topic: str, payload: str, retain: bool = False) -> None: ...
+
+
+class HeartbeatConfig(Protocol):
+    worker_id: str
+    heartbeat_interval: int
+
+
+class HeartbeatPublisher:
+    def __init__(self, mqtt_client: Publishable, config: HeartbeatConfig) -> None:
+        self.mqtt_client = mqtt_client
+        self.config = config
+        self._timer: threading.Timer | None = None
+        self._stopped = threading.Event()
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        self._stopped.clear()
+        self._publish()
+
+    def stop(self) -> None:
+        self._stopped.set()
+        with self._lock:
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+
+    def _publish(self) -> None:
+        if self._stopped.is_set():
+            return
+
+        heartbeat = {
+            "worker_id": self.config.worker_id,
+            "status": "idle",
+            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "version": "0.1.0",
+        }
+        self.mqtt_client.publish(
+            f"workers/{self.config.worker_id}/heartbeat",
+            json.dumps(heartbeat),
+        )
+        self.mqtt_client.publish(
+            f"workers/{self.config.worker_id}/status",
+            "idle",
+            retain=True,
+        )
+        logger.debug("Published heartbeat", extra={"worker_id": self.config.worker_id})
+        self._schedule_next()
+
+    def _schedule_next(self) -> None:
+        with self._lock:
+            if self._stopped.is_set():
+                return
+            self._timer = threading.Timer(self.config.heartbeat_interval, self._publish)
+            self._timer.daemon = True
+            self._timer.start()

--- a/worker/src/ai_swarm_worker/main.py
+++ b/worker/src/ai_swarm_worker/main.py
@@ -1,6 +1,33 @@
 from __future__ import annotations
 
+import json
+import logging
+import signal
+import sys
+import threading
+from datetime import UTC, datetime
+
 import click
+
+from ai_swarm_worker.config import WorkerConfig
+from ai_swarm_worker.heartbeat import HeartbeatPublisher
+from ai_swarm_worker.mqtt import MQTTClient
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "ts": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "level": record.levelname,
+            "msg": record.getMessage(),
+        }
+        return json.dumps(payload)
+
+
+def setup_logging(level: str) -> None:
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    logging.basicConfig(level=level.upper(), handlers=[handler], force=True)
 
 
 @click.group()
@@ -11,10 +38,40 @@ def cli() -> None:
 @cli.command()
 def start() -> None:
     """Start the worker daemon."""
-    click.echo("worker started")
+    config = WorkerConfig()
+    setup_logging(config.log_level)
+    logger = logging.getLogger(__name__)
+    stop_event = threading.Event()
+    mqtt_client = MQTTClient(config)
+    heartbeat = HeartbeatPublisher(mqtt_client, config)
+
+    def request_stop(signum: int, frame: object | None) -> None:
+        del frame
+        logger.info("Received shutdown signal", extra={"signal": signum})
+        stop_event.set()
+
+    signal.signal(signal.SIGTERM, request_stop)
+    signal.signal(signal.SIGINT, request_stop)
+
+    try:
+        mqtt_client.connect()
+        heartbeat.start()
+        mqtt_client.subscribe_tasks(
+            lambda payload: logger.info("Received task", extra={"payload": payload})
+        )
+        stop_event.wait()
+    finally:
+        heartbeat.stop()
+        mqtt_client.disconnect()
 
 
 @cli.command()
 def stop() -> None:
     """Stop the worker daemon."""
-    click.echo("worker stopped")
+    click.echo("stop is not implemented yet")
+
+
+@cli.command()
+def status() -> None:
+    """Show worker daemon status."""
+    click.echo("status is not implemented yet")

--- a/worker/src/ai_swarm_worker/mqtt.py
+++ b/worker/src/ai_swarm_worker/mqtt.py
@@ -1,1 +1,73 @@
-# TODO: implement MQTT client (Task 4)
+from __future__ import annotations
+
+import logging
+import ssl
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+import paho.mqtt.client as mqtt
+
+from ai_swarm_worker.config import WorkerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class MQTTClient:
+    def __init__(self, config: WorkerConfig) -> None:
+        self.config = config
+        self.client = mqtt.Client(
+            callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+            client_id=config.worker_id,
+            clean_session=True,
+        )
+        self.client.username_pw_set(config.mqtt_username, config.mqtt_password)
+        self.client.will_set(
+            f"workers/{config.worker_id}/status",
+            payload="offline",
+            qos=1,
+            retain=True,
+        )
+
+    def connect(self) -> None:
+        parsed_url = urlparse(self.config.mqtt_broker_url)
+        if (
+            parsed_url.scheme != "mqtts"
+            or not parsed_url.hostname
+            or parsed_url.port is None
+        ):
+            msg = "mqtt_broker_url must use mqtts://host:port"
+            raise ValueError(msg)
+
+        tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        tls_context.load_default_certs()
+        self.client.tls_set_context(tls_context)
+        logger.info(
+            "Connecting to MQTT broker",
+            extra={"host": parsed_url.hostname, "port": parsed_url.port},
+        )
+        self.client.connect_async(
+            parsed_url.hostname,
+            parsed_url.port,
+            self.config.mqtt_keepalive,
+        )
+        self.client.loop_start()
+
+    def subscribe_tasks(self, on_message: Callable[[str], None]) -> None:
+        def handle_message(
+            client: mqtt.Client,
+            userdata: object,
+            message: mqtt.MQTTMessage,
+        ) -> None:
+            del client, userdata
+            on_message(message.payload.decode("utf-8"))
+
+        self.client.on_message = handle_message
+        self.client.subscribe("$share/impl-workers/tasks/impl/+", qos=1)
+
+    def publish(self, topic: str, payload: str, retain: bool = False) -> None:
+        self.client.publish(topic, payload=payload, qos=1, retain=retain)
+
+    def disconnect(self) -> None:
+        self.publish(f"workers/{self.config.worker_id}/status", "offline", retain=True)
+        self.client.loop_stop()
+        self.client.disconnect()

--- a/worker/tests/test_config.py
+++ b/worker/tests/test_config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from ai_swarm_worker.config import WorkerConfig
+
+
+def test_worker_id_defaults_to_hostname_pid(monkeypatch) -> None:
+    monkeypatch.setenv("AI_SWARM_MQTT_BROKER_URL", "mqtts://mqtt.example.com:8883")
+    monkeypatch.setenv("AI_SWARM_MQTT_USERNAME", "worker")
+    monkeypatch.setenv("AI_SWARM_MQTT_PASSWORD", "secret")
+
+    config = WorkerConfig()
+
+    assert "-" in config.worker_id
+
+
+def test_custom_worker_id(monkeypatch) -> None:
+    monkeypatch.setenv("AI_SWARM_WORKER_ID", "my-custom-worker")
+    monkeypatch.setenv("AI_SWARM_MQTT_BROKER_URL", "mqtts://mqtt.example.com:8883")
+    monkeypatch.setenv("AI_SWARM_MQTT_USERNAME", "worker")
+    monkeypatch.setenv("AI_SWARM_MQTT_PASSWORD", "secret")
+
+    config = WorkerConfig()
+
+    assert config.worker_id == "my-custom-worker"

--- a/worker/tests/test_heartbeat.py
+++ b/worker/tests/test_heartbeat.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import ai_swarm_worker.heartbeat as heartbeat_module
+from ai_swarm_worker.heartbeat import HeartbeatPublisher
+
+
+class FakeTimer:
+    def __init__(self, interval: int, function) -> None:
+        self.interval = interval
+        self.function = function
+        self.daemon = False
+        self.cancelled = False
+
+    def start(self) -> None:
+        pass
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+def test_start_publishes_heartbeat_and_status() -> None:
+    mqtt_client = Mock()
+    config = Mock(worker_id="worker-1", heartbeat_interval=60)
+    publisher = HeartbeatPublisher(mqtt_client, config)
+
+    publisher.start()
+    publisher.stop()
+
+    mqtt_client.publish.assert_any_call(
+        "workers/worker-1/heartbeat",
+        mqtt_client.publish.call_args_list[0].args[1],
+    )
+    mqtt_client.publish.assert_any_call("workers/worker-1/status", "idle", retain=True)
+
+
+def test_stop_cancels_timer_and_stops_further_publishing(monkeypatch) -> None:
+    timers: list[FakeTimer] = []
+
+    def create_timer(interval: int, function) -> FakeTimer:
+        timer = FakeTimer(interval, function)
+        timers.append(timer)
+        return timer
+
+    monkeypatch.setattr(heartbeat_module.threading, "Timer", create_timer)
+    mqtt_client = Mock()
+    config = Mock(worker_id="worker-1", heartbeat_interval=60)
+    publisher = HeartbeatPublisher(mqtt_client, config)
+
+    publisher.start()
+    publisher.stop()
+    publish_count = mqtt_client.publish.call_count
+    timers[0].function()
+
+    assert timers[0].cancelled is True
+    assert mqtt_client.publish.call_count == publish_count


### PR DESCRIPTION
## Summary

- 實作 `WorkerConfig`（`pydantic-settings`，env prefix `AI_SWARM_`）
- 實作 `MQTTClient`（paho-mqtt v2 CallbackAPIVersion.VERSION2，TLS，LWT，shared subscription `$share/impl-workers/tasks/impl/+`，QoS 1）
- 新建 `HeartbeatPublisher`（`threading.Timer` repeating，每 `heartbeat_interval` 秒發 heartbeat JSON + retained status）
- 完整實作 `main.py` CLI：`worker start`（SIGTERM/SIGINT 優雅關閉），`worker stop`/`status` stub
- 新增 `pydantic-settings>=2.7` 至 `pyproject.toml`
- 新增測試：`test_config.py`（WorkerConfig env 讀取）、`test_heartbeat.py`（mock MQTTClient 驗證 publish 行為）

## Test plan

- [ ] `uv sync`（需網路，沙箱外執行）
- [ ] `uv run ruff check src tests` — 已驗證通過
- [ ] `uv run pytest` — task + heartbeat 5 tests 通過；config tests 需 pydantic-settings 安裝後驗證
- [ ] 設定環境變數 `AI_SWARM_MQTT_BROKER_URL` / `AI_SWARM_MQTT_USERNAME` / `AI_SWARM_MQTT_PASSWORD`，執行 `worker start` 確認連線 HiveMQ Cloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)