### PR TITLE
feat: task execution engine — claude CLI + git worktree (#5)

### DIFF
--- a/worker/src/ai_swarm_worker/executor.py
+++ b/worker/src/ai_swarm_worker/executor.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import threading
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from ai_swarm_worker.config import WorkerConfig
+from ai_swarm_worker.mqtt import MQTTClient
+from ai_swarm_worker.task import Task
+
+logger = logging.getLogger(__name__)
+
+REPOS_CACHE = Path.home() / ".ai-swarm" / "repos"
+WORKTREES_DIR = Path("/tmp/ai-swarm")
+VERSION = "0.1.0"
+
+
+@dataclass
+class TaskResult:
+    task_id: str
+    worker_id: str
+    status: str  # "success" | "failure" | "timeout"
+    exit_code: int | None
+    branch: str | None
+    elapsed_seconds: float
+    error: str | None = None
+
+
+class TaskExecutor:
+    def __init__(self, mqtt_client: MQTTClient, config: WorkerConfig) -> None:
+        self.mqtt_client = mqtt_client
+        self.config = config
+        self._lock = threading.Lock()
+        self._busy = False
+
+    @property
+    def is_busy(self) -> bool:
+        return self._busy
+
+    def handle_message(self, payload: str) -> None:
+        """Called by MQTT on_message — runs in MQTT network thread."""
+        try:
+            task = Task.model_validate_json(payload)
+        except ValidationError:
+            logger.error(
+                "Invalid task payload",
+                extra={"payload_preview": payload[:200]},
+            )
+            return
+
+        with self._lock:
+            if self._busy:
+                logger.warning(
+                    "Worker busy, dropping task",
+                    extra={"task_id": task.task_id},
+                )
+                return
+            self._busy = True
+
+        thread = threading.Thread(target=self._execute, args=(task,), daemon=True)
+        thread.start()
+
+    def _execute(self, task: Task) -> None:
+        start = datetime.now(UTC)
+        branch = f"ai/{task.task_id}"
+        worktree_path = WORKTREES_DIR / task.task_id
+
+        try:
+            logger.info(
+                "Task started",
+                extra={"task_id": task.task_id, "repo": task.repo},
+            )
+            self._publish_progress(task, "running", 0, "starting")
+
+            repo_path = self._ensure_repo(task.repo)
+            self._create_worktree(repo_path, worktree_path, branch)
+
+            prompt_file = worktree_path / "task-prompt.md"
+            prompt_file.write_text(task.prompt, encoding="utf-8")
+
+            exit_code = self._run_claude(task, worktree_path, start)
+
+            elapsed = (datetime.now(UTC) - start).total_seconds()
+            status = "success" if exit_code == 0 else "failure"
+
+            result = TaskResult(
+                task_id=task.task_id,
+                worker_id=self.config.worker_id,
+                status=status,
+                exit_code=exit_code,
+                branch=branch,
+                elapsed_seconds=elapsed,
+            )
+            logger.info(
+                "Task finished",
+                extra={"task_id": task.task_id, "status": status},
+            )
+
+        except TimeoutError:
+            elapsed = (datetime.now(UTC) - start).total_seconds()
+            result = TaskResult(
+                task_id=task.task_id,
+                worker_id=self.config.worker_id,
+                status="timeout",
+                exit_code=None,
+                branch=branch,
+                elapsed_seconds=elapsed,
+                error=f"Exceeded {task.timeout_seconds}s timeout",
+            )
+            logger.warning("Task timed out", extra={"task_id": task.task_id})
+
+        except Exception as exc:  # noqa: BLE001
+            elapsed = (datetime.now(UTC) - start).total_seconds()
+            result = TaskResult(
+                task_id=task.task_id,
+                worker_id=self.config.worker_id,
+                status="failure",
+                exit_code=None,
+                branch=None,
+                elapsed_seconds=elapsed,
+                error=str(exc),
+            )
+            logger.exception("Task failed", extra={"task_id": task.task_id})
+
+        finally:
+            self._cleanup_worktree(worktree_path)
+            self._busy = False
+
+        self._publish_result(task, result)
+
+    def _ensure_repo(self, repo: str) -> Path:
+        repo_dir_name = repo.replace("/", "-")
+        repo_path = REPOS_CACHE / repo_dir_name
+        REPOS_CACHE.mkdir(parents=True, exist_ok=True)
+
+        if not repo_path.exists():
+            logger.info("Cloning repo", extra={"repo": repo})
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    f"https://github.com/{repo}.git",
+                    str(repo_path),
+                ],
+                check=True,
+                capture_output=True,
+            )
+        else:
+            subprocess.run(
+                ["git", "-C", str(repo_path), "pull", "--ff-only"],
+                check=False,
+                capture_output=True,
+            )
+        return repo_path
+
+    def _create_worktree(
+        self,
+        repo_path: Path,
+        worktree_path: Path,
+        branch: str,
+    ) -> None:
+        WORKTREES_DIR.mkdir(parents=True, exist_ok=True)
+        if worktree_path.exists():
+            shutil.rmtree(worktree_path)
+
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_path),
+                "worktree",
+                "add",
+                str(worktree_path),
+                "-b",
+                branch,
+            ],
+            check=True,
+            capture_output=True,
+        )
+        logger.info(
+            "Worktree created",
+            extra={"path": str(worktree_path), "branch": branch},
+        )
+
+    def _run_claude(self, task: Task, cwd: Path, start: datetime) -> int:
+        cmd = [
+            "claude",
+            "--print",
+            "--prompt-file",
+            "task-prompt.md",
+            "--dangerously-skip-permissions",
+        ]
+
+        proc = subprocess.Popen(
+            cmd,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+
+        last_line = ""
+        last_progress_at = 0.0
+
+        try:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                line = line.rstrip()
+                if line:
+                    last_line = line
+                    logger.debug("claude: %s", line)
+
+                elapsed = (datetime.now(UTC) - start).total_seconds()
+                if elapsed - last_progress_at >= 10:
+                    self._publish_progress(task, "running", elapsed, last_line)
+                    last_progress_at = elapsed
+
+                if elapsed > task.timeout_seconds:
+                    proc.kill()
+                    raise TimeoutError
+
+            proc.wait(timeout=5)
+            return proc.returncode if proc.returncode is not None else 1
+
+        except TimeoutError:
+            proc.kill()
+            raise
+
+    def _cleanup_worktree(self, worktree_path: Path) -> None:
+        if worktree_path.exists():
+            try:
+                result = subprocess.run(
+                    ["git", "-C", str(worktree_path), "rev-parse", "--git-common-dir"],
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode == 0:
+                    common_dir = result.stdout.strip()
+                    repo_root = Path(common_dir).parent
+                    subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(repo_root),
+                            "worktree",
+                            "remove",
+                            "--force",
+                            str(worktree_path),
+                        ],
+                        capture_output=True,
+                    )
+                else:
+                    shutil.rmtree(worktree_path)
+            except Exception:  # noqa: BLE001
+                shutil.rmtree(worktree_path, ignore_errors=True)
+
+    def _publish_progress(
+        self,
+        task: Task,
+        status: str,
+        elapsed: float,
+        last_line: str,
+    ) -> None:
+        topic = f"tasks/{task.task_id}/progress"
+        payload = json.dumps({
+            "task_id": task.task_id,
+            "worker_id": self.config.worker_id,
+            "status": status,
+            "elapsed_seconds": round(elapsed, 1),
+            "last_output_line": last_line[:500],
+            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        })
+        self.mqtt_client.publish(topic, payload)
+
+    def _publish_result(self, task: Task, result: TaskResult) -> None:
+        topic = f"tasks/{task.task_id}/result"
+        payload = json.dumps({
+            "task_id": result.task_id,
+            "worker_id": result.worker_id,
+            "status": result.status,
+            "exit_code": result.exit_code,
+            "branch": result.branch,
+            "elapsed_seconds": round(result.elapsed_seconds, 1),
+            "error": result.error,
+            "timestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        })
+        self.mqtt_client.publish(topic, payload)

--- a/worker/src/ai_swarm_worker/main.py
+++ b/worker/src/ai_swarm_worker/main.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 import click
 
 from ai_swarm_worker.config import WorkerConfig
+from ai_swarm_worker.executor import TaskExecutor
 from ai_swarm_worker.heartbeat import HeartbeatPublisher
 from ai_swarm_worker.mqtt import MQTTClient
 
@@ -44,6 +45,7 @@ def start() -> None:
     stop_event = threading.Event()
     mqtt_client = MQTTClient(config)
     heartbeat = HeartbeatPublisher(mqtt_client, config)
+    executor = TaskExecutor(mqtt_client, config)
 
     def request_stop(signum: int, frame: object | None) -> None:
         del frame
@@ -56,9 +58,7 @@ def start() -> None:
     try:
         mqtt_client.connect()
         heartbeat.start()
-        mqtt_client.subscribe_tasks(
-            lambda payload: logger.info("Received task", extra={"payload": payload})
-        )
+        mqtt_client.subscribe_tasks(executor.handle_message)
         stop_event.wait()
     finally:
         heartbeat.stop()

--- a/worker/tests/test_executor.py
+++ b/worker/tests/test_executor.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import ai_swarm_worker.executor as executor_module
+from ai_swarm_worker.executor import TaskExecutor, TaskResult
+from ai_swarm_worker.task import Task
+
+
+def make_task() -> Task:
+    return Task.model_validate(
+        {
+            "task_id": "task-123",
+            "type": "implementation",
+            "source": "github",
+            "repo": "owner/repo",
+            "ref": {
+                "issue_number": 42,
+                "pr_number": None,
+                "commit_sha": "abc123",
+            },
+            "labels": ["bug"],
+            "prompt": "Fix the failing test",
+            "priority": "normal",
+            "created_at": "2026-04-20T12:00:00Z",
+            "timeout_seconds": 600,
+        }
+    )
+
+
+def make_executor() -> TaskExecutor:
+    mqtt_client = Mock()
+    config = Mock(worker_id="worker-1")
+    return TaskExecutor(mqtt_client, config)
+
+
+def test_handle_message_invalid_json(monkeypatch) -> None:
+    executor = make_executor()
+    run = Mock()
+    monkeypatch.setattr(executor_module.subprocess, "run", run)
+
+    executor.handle_message("{invalid json")
+
+    run.assert_not_called()
+
+
+def test_handle_message_drops_when_busy(monkeypatch) -> None:
+    executor = make_executor()
+    executor._busy = True
+    thread = Mock()
+    monkeypatch.setattr(executor_module.threading, "Thread", Mock(return_value=thread))
+
+    executor.handle_message(make_task().model_dump_json())
+
+    thread.start.assert_not_called()
+
+
+def test_publish_progress() -> None:
+    executor = make_executor()
+    task = make_task()
+
+    executor._publish_progress(task, "running", 45.0, "Running tests")
+
+    topic, payload = executor.mqtt_client.publish.call_args.args
+    data = json.loads(payload)
+    assert topic == f"tasks/{task.task_id}/progress"
+    assert data["task_id"] == task.task_id
+    assert data["worker_id"] == "worker-1"
+    assert data["status"] == "running"
+    assert data["elapsed_seconds"] == 45.0
+    assert data["last_output_line"] == "Running tests"
+    assert data["timestamp"].endswith("Z")
+
+
+def test_publish_result() -> None:
+    executor = make_executor()
+    task = make_task()
+    result = TaskResult(
+        task_id=task.task_id,
+        worker_id="worker-1",
+        status="success",
+        exit_code=0,
+        branch="ai/task-123",
+        elapsed_seconds=12.34,
+    )
+
+    executor._publish_result(task, result)
+
+    topic, payload = executor.mqtt_client.publish.call_args.args
+    data = json.loads(payload)
+    assert topic == f"tasks/{task.task_id}/result"
+    assert data["task_id"] == task.task_id
+    assert data["worker_id"] == "worker-1"
+    assert data["status"] == "success"
+    assert data["exit_code"] == 0
+    assert data["branch"] == "ai/task-123"
+    assert data["elapsed_seconds"] == 12.3
+    assert data["error"] is None
+    assert data["timestamp"].endswith("Z")
+
+
+def test_cleanup_worktree_removes_on_failure(monkeypatch, tmp_path: Path) -> None:
+    executor = make_executor()
+    worktree_path = tmp_path / "worktree"
+    worktree_path.mkdir()
+
+    monkeypatch.setattr(
+        executor_module.subprocess,
+        "run",
+        Mock(return_value=SimpleNamespace(returncode=1, stdout="")),
+    )
+
+    executor._cleanup_worktree(worktree_path)
+
+    assert not worktree_path.exists()


### PR DESCRIPTION
## Summary

- 新增 `worker/src/ai_swarm_worker/executor.py`：`TaskExecutor` 類別，負責解析 MQTT 任務訊息、git clone/worktree 隔離、呼叫 `claude --print --prompt-file`、發布 progress/result 事件
- 修改 `worker/src/ai_swarm_worker/main.py`：將 `subscribe_tasks` lambda 替換為 `executor.handle_message`
- 新增 `worker/tests/test_executor.py`：5 個 mock-based 單元測試

## 技術細節

- 使用 `threading.Lock` 保護 busy state，MQTT 網路執行緒不被阻塞
- Repo cache 在 `~/.ai-swarm/repos/`，worktree 在 `/tmp/ai-swarm/{task_id}`
- Timeout 透過 wall-clock 檢查實作，超時後 `proc.kill()` + `raise TimeoutError`
- Result 以 MQTT publish 到 `tasks/{task_id}/result`，progress 每 10 秒一次

## Test plan

- [x] `uv run ruff check src tests` — All checks passed
- [x] `uv run pytest -v` — 12/12 passed（含 5 個新 executor 測試）
- [ ] pyright 有 3 個錯誤，全部為 Task 4 既有問題（`pydantic_settings` BaseSettings 假陽性 + paho-mqtt 型別存根不完整），Task 5 未引入新型別錯誤

🤖 Generated with [Claude Code](https://claude.com/claude-code)