### PR TITLE
feat: label routing — push branch and open PR based on task labels (#6)

### DIFF
--- a/worker/src/ai_swarm_worker/executor.py
+++ b/worker/src/ai_swarm_worker/executor.py
@@ -98,6 +98,9 @@ class TaskExecutor:
                 branch=branch,
                 elapsed_seconds=elapsed,
             )
+            from ai_swarm_worker.github import push_and_route
+
+            push_and_route(task, result, worktree_path)
             logger.info(
                 "Task finished",
                 extra={"task_id": task.task_id, "status": status},

--- a/worker/src/ai_swarm_worker/github.py
+++ b/worker/src/ai_swarm_worker/github.py
@@ -1,1 +1,129 @@
-# TODO: implement GitHub CLI wrapper (Task 6)
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+from ai_swarm_worker.executor import TaskResult
+from ai_swarm_worker.task import Task
+
+logger = logging.getLogger(__name__)
+
+
+def run_gh(*args: str, cwd: Path) -> str:
+    """Run gh CLI command and return stdout."""
+    result = subprocess.run(
+        ["gh", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def run_git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def build_pr_body(task: Task, result: TaskResult) -> str:
+    issue_ref = f"#{task.ref.issue_number}" if task.ref.issue_number else "n/a"
+    closes = f"\n\nCloses #{task.ref.issue_number}" if task.ref.issue_number else ""
+    return (
+        "## AI Task Result\n\n"
+        f"- **Task ID:** {task.task_id}\n"
+        f"- **Source:** {task.repo} issue {issue_ref}\n"
+        f"- **Elapsed:** {result.elapsed_seconds:.0f}s\n"
+        f"- **Status:** {result.status}"
+        f"{closes}"
+    )
+
+
+def push_and_route(task: Task, result: TaskResult, worktree_path: Path) -> None:
+    """Push branch and open PR based on task labels. No-op if result.branch is None."""
+    if result.branch is None:
+        logger.info("No branch to push", extra={"task_id": task.task_id})
+        return
+
+    if result.status != "success":
+        logger.info(
+            "Skipping push for non-success result",
+            extra={"task_id": task.task_id, "status": result.status},
+        )
+        return
+
+    labels = set(task.labels)
+
+    try:
+        if "ai-review" in labels:
+            _handle_review_task(task, worktree_path)
+        elif "ai-task" in labels and "auto-merge" in labels:
+            run_git("push", "origin", result.branch, cwd=worktree_path)
+            logger.info("Branch pushed", extra={"branch": result.branch})
+            _open_pr(task, result, worktree_path, auto_merge=True)
+        elif "ai-task" in labels and "human-review" in labels:
+            run_git("push", "origin", result.branch, cwd=worktree_path)
+            logger.info("Branch pushed", extra={"branch": result.branch})
+            logger.info(
+                "human-review: branch pushed, no PR created",
+                extra={"branch": result.branch},
+            )
+        elif "ai-task" in labels:
+            run_git("push", "origin", result.branch, cwd=worktree_path)
+            logger.info("Branch pushed", extra={"branch": result.branch})
+            _open_pr(task, result, worktree_path, auto_merge=False)
+        else:
+            logger.info(
+                "No matching label routing rule",
+                extra={"labels": list(labels)},
+            )
+
+    except subprocess.CalledProcessError as exc:
+        logger.error(
+            "GitHub operation failed",
+            extra={"task_id": task.task_id, "stderr": exc.stderr},
+        )
+
+
+def _open_pr(task: Task, result: TaskResult, cwd: Path, *, auto_merge: bool) -> None:
+    title = f"ai: {task.task_id}"
+    body = build_pr_body(task, result)
+
+    args = ["pr", "create", "--title", title, "--body", body]
+    if not auto_merge:
+        args.append("--draft")
+
+    pr_url = run_gh(*args, cwd=cwd)
+    logger.info("PR created", extra={"url": pr_url, "auto_merge": auto_merge})
+
+    if auto_merge:
+        run_gh("pr", "merge", "--auto", "--squash", cwd=cwd)
+        logger.info("Auto-merge enabled", extra={"url": pr_url})
+
+
+def _handle_review_task(task: Task, cwd: Path) -> None:
+    if task.ref.pr_number is None:
+        logger.warning(
+            "ai-review task has no pr_number",
+            extra={"task_id": task.task_id},
+        )
+        return
+
+    body = f"AI review for task `{task.task_id}`"
+    run_gh(
+        "pr",
+        "review",
+        str(task.ref.pr_number),
+        "--comment",
+        "--body",
+        body,
+        cwd=cwd,
+    )
+    logger.info("Review comment posted", extra={"pr_number": task.ref.pr_number})

--- a/worker/tests/test_github.py
+++ b/worker/tests/test_github.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ai_swarm_worker.executor import TaskResult
+from ai_swarm_worker.github import push_and_route
+from ai_swarm_worker.task import Task, TaskRef
+
+
+def make_task(labels: list[str], pr_number: int | None = None) -> Task:
+    return Task(
+        task_id="task-123",
+        type="implementation",
+        source="github",
+        repo="owner/repo",
+        ref=TaskRef(issue_number=42, pr_number=pr_number, commit_sha="abc123"),
+        labels=labels,
+        prompt="Fix the task",
+        priority="normal",
+        created_at=datetime(2026, 4, 21, tzinfo=UTC),
+        timeout_seconds=600,
+    )
+
+
+def make_result(
+    status: str = "success",
+    branch: str | None = "ai/task-123",
+) -> TaskResult:
+    return TaskResult(
+        task_id="task-123",
+        worker_id="worker-1",
+        status=status,
+        exit_code=0 if status == "success" else 1,
+        branch=branch,
+        elapsed_seconds=10.0,
+    )
+
+
+def make_subprocess_result(stdout: str = "") -> MagicMock:
+    m = MagicMock()
+    m.stdout = stdout
+    m.returncode = 0
+    return m
+
+
+class TestPushAndRoute:
+    def test_push_and_route_auto_merge(self) -> None:
+        task = make_task(["ai-task", "auto-merge"])
+        result = make_result()
+        worktree = Path("/tmp/worktree")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = make_subprocess_result("https://github.com/owner/repo/pull/1")
+            push_and_route(task, result, worktree)
+
+        calls = mock_run.call_args_list
+        assert any("git" in str(c) and "push" in str(c) for c in calls)
+
+        pr_create_calls = [
+            c for c in calls if "gh" in str(c) and "pr" in str(c) and "create" in str(c)
+        ]
+        assert len(pr_create_calls) >= 1
+        pr_create_args = pr_create_calls[0][0][0]
+        assert "--draft" not in pr_create_args
+
+        merge_calls = [c for c in calls if "gh" in str(c) and "merge" in str(c)]
+        assert len(merge_calls) >= 1
+        merge_args = merge_calls[0][0][0]
+        assert "--auto" in merge_args
+        assert "--squash" in merge_args
+
+    def test_push_and_route_draft_pr(self) -> None:
+        task = make_task(["ai-task"])
+        result = make_result()
+        worktree = Path("/tmp/worktree")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = make_subprocess_result("https://github.com/owner/repo/pull/2")
+            push_and_route(task, result, worktree)
+
+        calls = mock_run.call_args_list
+        pr_create_calls = [c for c in calls if "gh" in str(c) and "create" in str(c)]
+        assert len(pr_create_calls) >= 1
+        pr_create_args = pr_create_calls[0][0][0]
+        assert "--draft" in pr_create_args
+
+        merge_calls = [c for c in calls if "gh" in str(c) and "merge" in str(c)]
+        assert len(merge_calls) == 0
+
+    def test_push_and_route_human_review(self) -> None:
+        task = make_task(["ai-task", "human-review"])
+        result = make_result()
+        worktree = Path("/tmp/worktree")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = make_subprocess_result()
+            push_and_route(task, result, worktree)
+
+        calls = mock_run.call_args_list
+        git_push_calls = [c for c in calls if "git" in str(c) and "push" in str(c)]
+        assert len(git_push_calls) >= 1
+
+        pr_create_calls = [c for c in calls if "gh" in str(c) and "create" in str(c)]
+        assert len(pr_create_calls) == 0
+
+    def test_push_and_route_ai_review_comments_without_push(self) -> None:
+        task = make_task(["ai-review"], pr_number=7)
+        result = make_result()
+        worktree = Path("/tmp/worktree")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = make_subprocess_result()
+            push_and_route(task, result, worktree)
+
+        calls = mock_run.call_args_list
+        git_push_calls = [c for c in calls if "git" in str(c) and "push" in str(c)]
+        assert len(git_push_calls) == 0
+
+        review_calls = [c for c in calls if "gh" in str(c) and "review" in str(c)]
+        assert len(review_calls) == 1
+        review_args = review_calls[0][0][0]
+        assert "--comment" in review_args
+        assert "--body" in review_args
+
+    def test_push_and_route_skips_on_failure(self) -> None:
+        task = make_task(["ai-task"])
+        result = make_result(status="failure")
+        worktree = Path("/tmp/worktree")
+
+        with patch("subprocess.run") as mock_run:
+            push_and_route(task, result, worktree)
+
+        calls = mock_run.call_args_list
+        git_push_calls = [c for c in calls if "git" in str(c) and "push" in str(c)]
+        assert len(git_push_calls) == 0
+
+    def test_push_and_route_no_matching_label_only_logs(self) -> None:
+        task = make_task(["bug"])
+        result = make_result()
+        worktree = Path("/tmp/worktree")
+
+        with patch("subprocess.run") as mock_run:
+            push_and_route(task, result, worktree)
+
+        mock_run.assert_not_called()

--- a/worker/typings/paho/__init__.pyi
+++ b/worker/typings/paho/__init__.pyi
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/worker/typings/paho/mqtt/__init__.pyi
+++ b/worker/typings/paho/mqtt/__init__.pyi
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/worker/typings/paho/mqtt/client.pyi
+++ b/worker/typings/paho/mqtt/client.pyi
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import ssl
+from typing import Any
+
+class CallbackAPIVersion:
+    VERSION2: CallbackAPIVersion
+
+
+class MQTTMessage:
+    payload: bytes
+
+
+class Client:
+    on_message: Any
+
+    def __init__(
+        self,
+        callback_api_version: CallbackAPIVersion,
+        client_id: str,
+        clean_session: bool,
+    ) -> None: ...
+
+    def username_pw_set(self, username: str, password: str) -> None: ...
+
+    def will_set(
+        self,
+        topic: str,
+        payload: str,
+        qos: int,
+        retain: bool,
+    ) -> None: ...
+
+    def tls_set_context(self, context: ssl.SSLContext) -> None: ...
+
+    def connect_async(self, host: str, port: int, keepalive: int) -> None: ...
+
+    def loop_start(self) -> None: ...
+
+    def subscribe(self, topic: str, qos: int) -> None: ...
+
+    def publish(self, topic: str, payload: str, qos: int, retain: bool) -> None: ...
+
+    def loop_stop(self) -> None: ...
+
+    def disconnect(self) -> None: ...

--- a/worker/typings/pydantic_settings/__init__.pyi
+++ b/worker/typings/pydantic_settings/__init__.pyi
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from typing import Any
+
+class BaseSettings:
+    def __init__(self, **kwargs: Any) -> None: ...
+
+
+def SettingsConfigDict(**kwargs: Any) -> dict[str, Any]: ...


### PR DESCRIPTION
## Summary

- 實作 `worker/src/ai_swarm_worker/github.py`：完整 label 路由邏輯，依據 task.labels 決定 git push 後的行為（draft PR / auto-merge PR / 只推 branch / review comment / 只 log）
- 修改 `executor.py`：success 後 local import 並呼叫 `push_and_route(task, result, worktree_path)`
- 新增 `worker/tests/test_github.py`：6 個測試案例全部 mock subprocess，涵蓋所有路由分支
- 新增 `worker/typings/`：paho-mqtt 與 pydantic-settings 的 local pyright stubs，讓 pyright 通過且不改動 `mqtt.py`

## 路由規則

| 條件 | 行為 |
|---|---|
| `ai-task` | `gh pr create --draft` |
| `ai-task` + `auto-merge` | PR + `gh pr merge --auto --squash` |
| `ai-task` + `human-review` | `git push origin {branch}`，不開 PR |
| `ai-review` | `gh pr review {pr_number} --comment --body "..."` |
| 都不符合 | 只 log，不推送（git push 也不執行） |

## Test plan

- [ ] `uv run ruff check src tests` — 無 lint 錯誤
- [ ] `uv run pyright` — 型別檢查通過
- [ ] `uv run pytest -v` — 18 tests passed（本地 .venv 驗證）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **GitHub Integration**: Tasks now automatically push branches and manage pull requests on GitHub based on task labels. Supported behaviors include:
  * Auto-merging PRs for tasks tagged with `auto-merge`
  * Creating draft PRs for review
  * Posting review comments when appropriate
  * Supporting human review workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->