### PR TITLE
docs: deploy playbook and E2E smoke test prep (Tasks 7-8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,10 @@ Claude Code 不直接寫程式碼，除非 Codex 明確無法處理。
 |---|---|---|
 | Task 1 — Repo scaffold | ✅ 完成 | 目錄結構、CI、GitHub repo 建立 |
 | Task 2 — Task schema | ✅ 完成 | `schema/task.schema.json` + Python types `worker/src/ai_swarm_worker/task.py` |
-| Task 3 — Cloudflare Worker bridge | ⏳ 待實作 | GitHub webhook → MQTT publish |
-| Task 4 — Worker daemon skeleton | ⏳ 待實作 | MQTT 連線、shared subscription、heartbeat |
-| Task 5 — Worker 任務執行 | ⏳ 待實作 | Claude Code CLI 呼叫、git worktree 隔離 |
-| Task 6 — Label 路由邏輯 | ⏳ 待實作 | 依 label 決定 PR 推送策略 |
+| Task 3 — Cloudflare Worker bridge | ✅ 完成 | bridge/ TypeScript Worker 實作完成 |
+| Task 4 — Worker daemon skeleton | ✅ 完成 | Python worker daemon with MQTT |
+| Task 5 — Worker 任務執行 | ✅ 完成 | Claude Code CLI 呼叫、git worktree 隔離 |
+| Task 6 — Label 路由邏輯 | ✅ 完成 | 依 label 決定 PR 推送策略 |
 | Task 7 — E2E smoke test | ⏳ 待實作 | 一張 issue 走完整流程 |
 | Task 8 — Deploy playbook | ⏳ 待實作 | HiveMQ / Tailscale / Cloudflare 設定文件 |
 

--- a/docs/smoke-test-results.md
+++ b/docs/smoke-test-results.md
@@ -1,0 +1,51 @@
+# E2E Smoke Test Results
+
+## Environment
+
+| Item | Value |
+|---|---|
+| Date | YYYY-MM-DD |
+| Worker version | 0.1.0 |
+| Worker machine | (hostname) |
+| HiveMQ broker | (URL) |
+| Test repo | (owner/repo) |
+
+## Pre-flight
+
+Run `./scripts/smoke-test.sh` and paste results here.
+
+## Test Issue
+
+- URL: https://github.com/{owner}/{repo}/issues/{number}
+- Title: `[test] ai-task smoke test: add hello world function`
+- Labels: `ai-task`, `auto-merge`
+- Created at: HH:MM:SS
+
+## Verification Checklist
+
+| Step | Expected | Actual | Time |
+|---|---|---|---|
+| GitHub webhook triggered | CF Worker receives POST | | |
+| MQTT published | HiveMQ dashboard shows message | | |
+| Worker picks up task | Worker log shows task_id | | |
+| Claude CLI executes | Worker log shows claude output | | |
+| PR opened | GitHub PR created | | |
+| CI passes → auto-merge | PR merged | | |
+| Total elapsed | < 5 minutes | | |
+
+## Fault Tolerance Test
+
+| Test | Expected | Result |
+|---|---|---|
+| Kill worker mid-execution | Message returns to queue | |
+| Second worker picks up | Task completes on worker B | |
+
+## Notes
+
+<!-- Any deviations, errors, or observations -->
+
+## Conclusion
+
+[ ] PASS — All checks passed, MVP success criteria met
+[ ] PARTIAL — Some checks passed with workarounds
+[ ] FAIL — Critical issues found (describe below)

--- a/infra/cloudflare-deploy.md
+++ b/infra/cloudflare-deploy.md
@@ -1,0 +1,109 @@
+# Cloudflare Worker Deployment
+
+This guide deploys the AI Swarm bridge as a Cloudflare Worker. The bridge receives GitHub webhook events and publishes tasks to MQTT.
+
+## Prerequisites
+
+- Node.js 18+
+- pnpm
+- A Cloudflare account with Wrangler access
+- A HiveMQ Cloud broker URL, username, and password
+- A GitHub webhook secret
+
+Install Wrangler globally:
+
+```bash
+pnpm add -g wrangler
+```
+
+Log in to Cloudflare:
+
+```bash
+wrangler login
+```
+
+## Configure Secrets
+
+Generate a webhook secret:
+
+```bash
+openssl rand -hex 32
+```
+
+From the `bridge/` directory, add the required secrets:
+
+```bash
+cd bridge
+wrangler secret put GITHUB_WEBHOOK_SECRET
+wrangler secret put MQTT_BROKER_URL
+wrangler secret put MQTT_USERNAME
+wrangler secret put MQTT_PASSWORD
+```
+
+Use the same `GITHUB_WEBHOOK_SECRET` value later when configuring the GitHub webhook.
+
+Use the MQTT broker URL format expected by the bridge, for example:
+
+```text
+mqtts://YOUR-CLUSTER.s1.YOUR-REGION.hivemq.cloud:8883
+```
+
+## Deploy
+
+Deploy the Worker from the `bridge/` directory:
+
+```bash
+pnpm deploy
+```
+
+List deployments and copy the Worker URL:
+
+```bash
+wrangler deployments list
+```
+
+The deployed URL should look like:
+
+```text
+https://ai-swarm-bridge.YOUR-SUBDOMAIN.workers.dev
+```
+
+## GitHub Webhook Setup
+
+In the target GitHub repository:
+
+1. Open **Settings**.
+2. Open **Webhooks**.
+3. Select **Add webhook**.
+4. Set **Payload URL** to the Cloudflare Worker URL.
+5. Set **Content type** to `application/json`.
+6. Set **Secret** to the same value stored in `GITHUB_WEBHOOK_SECRET`.
+7. Under **Which events would you like to trigger this webhook?**, select **Let me select individual events**.
+8. Enable **Issues** and **Pull requests**.
+9. Keep **Active** checked.
+10. Select **Add webhook**.
+
+See [github-webhook-setup.md](github-webhook-setup.md) for detailed webhook testing and redelivery steps.
+
+## Troubleshooting
+
+### 401 Signature Mismatch
+
+Cause: GitHub and Cloudflare Worker are using different webhook secret values.
+
+Fix:
+
+- Re-run `wrangler secret put GITHUB_WEBHOOK_SECRET` in `bridge/`.
+- Paste the exact same secret into the GitHub webhook **Secret** field.
+- Redeliver a recent GitHub webhook delivery.
+
+### MQTT Publish Failure
+
+Cause: Broker URL, credentials, or ACLs are incorrect.
+
+Fix:
+
+- Confirm `MQTT_BROKER_URL` uses `mqtts://` and port `8883`.
+- Confirm the hostname matches the HiveMQ cluster URL.
+- Confirm `MQTT_USERNAME` and `MQTT_PASSWORD` match HiveMQ Access Management credentials.
+- Confirm HiveMQ ACLs allow publish access to `tasks/#` and `workers/#`.

--- a/infra/github-webhook-setup.md
+++ b/infra/github-webhook-setup.md
@@ -1,3 +1,127 @@
 # GitHub Webhook Setup
 
-> Placeholder — GitHub webhook registration and secret configuration to be added.
+This guide connects a GitHub repository to the AI Swarm Cloudflare Worker bridge.
+
+The Payload URL comes from the deployed Cloudflare Worker. See [cloudflare-deploy.md](cloudflare-deploy.md) for deployment and URL discovery.
+
+## Required Events
+
+Select these webhook events:
+
+- **Issues**
+- **Pull requests**
+
+Issues create implementation tasks. Pull request events create review or follow-up tasks when the routing labels match the AI Swarm configuration.
+
+## Add the Webhook
+
+1. Open the target GitHub repository.
+2. Go to **Settings → Webhooks**.
+3. Select **Add webhook**.
+4. Fill in the fields below.
+5. Select **Add webhook**.
+
+## Field Reference
+
+### Payload URL
+
+Set this to the Cloudflare Worker URL, for example:
+
+```text
+https://ai-swarm-bridge.YOUR-SUBDOMAIN.workers.dev
+```
+
+Get this URL with:
+
+```bash
+cd bridge
+wrangler deployments list
+```
+
+### Content Type
+
+Select:
+
+```text
+application/json
+```
+
+The bridge expects JSON webhook payloads.
+
+### Secret
+
+Use the same value stored in the Cloudflare Worker secret:
+
+```bash
+cd bridge
+wrangler secret put GITHUB_WEBHOOK_SECRET
+```
+
+Generate a strong secret with:
+
+```bash
+openssl rand -hex 32
+```
+
+GitHub signs webhook requests with this secret. The bridge rejects requests when the signature does not match.
+
+### Events
+
+Choose **Let me select individual events** and enable:
+
+- **Issues**
+- **Pull requests**
+
+### Active
+
+Keep **Active** checked. Inactive webhooks are saved but do not send deliveries.
+
+## Test the Webhook
+
+After creating the webhook:
+
+1. Open **Settings → Webhooks**.
+2. Select the AI Swarm webhook.
+3. Open **Recent Deliveries**.
+4. Confirm GitHub sent a `ping` delivery.
+5. Select the delivery and inspect the response status.
+
+Expected result:
+
+- HTTP status is `2xx`.
+- Response does not show a signature error.
+- Cloudflare Worker logs show the request was received.
+
+Create or update a test issue with the `ai-task` label to trigger an issue delivery.
+
+## Redeliver for Testing
+
+To retry a webhook delivery:
+
+1. Open **Settings → Webhooks**.
+2. Select the AI Swarm webhook.
+3. Open **Recent Deliveries**.
+4. Select a delivery.
+5. Select **Redeliver**.
+
+Use redelivery after changing Cloudflare secrets, MQTT credentials, or bridge code. It lets you test the same payload without creating another GitHub issue.
+
+## Troubleshooting
+
+### 401 Response
+
+Cause: The GitHub webhook secret does not match `GITHUB_WEBHOOK_SECRET` in Cloudflare.
+
+Fix: Update one side so both values are identical, then redeliver the failed delivery.
+
+### No Deliveries
+
+Cause: The webhook is inactive or the selected event type does not match the GitHub action.
+
+Fix: Confirm **Active** is checked and **Issues** plus **Pull requests** are selected.
+
+### MQTT Task Not Published
+
+Cause: The webhook reached Cloudflare, but bridge MQTT configuration failed.
+
+Fix: Check Cloudflare Worker logs and verify `MQTT_BROKER_URL`, `MQTT_USERNAME`, `MQTT_PASSWORD`, and HiveMQ ACLs.

--- a/infra/hivemq-setup.md
+++ b/infra/hivemq-setup.md
@@ -1,3 +1,130 @@
-# HiveMQ Setup
+# HiveMQ Cloud Setup
 
-> Placeholder — HiveMQ Cloud cluster setup instructions to be added.
+This guide creates a HiveMQ Cloud MQTT broker for AI Swarm. The MVP uses HiveMQ Cloud directly, so worker machines do not need public inbound networking.
+
+## Create an Account
+
+1. Open https://www.hivemq.com/mqtt-cloud/.
+2. Create or sign in to a HiveMQ Cloud account.
+3. Select the **Serverless** free plan.
+
+## Create a Cluster
+
+1. In HiveMQ Cloud, create a new Serverless cluster.
+2. Select the preferred cloud region.
+3. Wait for the cluster status to become ready.
+4. Copy the cluster URL.
+
+The URL format is:
+
+```text
+{cluster-id}.s1.{region}.hivemq.cloud
+```
+
+Use port `8883` with TLS for MQTT clients.
+
+## Create Credentials
+
+1. Open the cluster.
+2. Go to **Access Management**.
+3. Open **Credentials**.
+4. Create a new username and password for AI Swarm.
+5. Store the password securely. It will be used by both the Cloudflare bridge and worker daemon.
+
+## Configure ACLs
+
+In **Access Management**, configure ACL permissions for the AI Swarm credential.
+
+Allow subscribe and publish access to:
+
+```text
+tasks/#
+workers/#
+```
+
+Required permissions:
+
+| Topic filter | Subscribe | Publish |
+|---|---:|---:|
+| `tasks/#` | Yes | Yes |
+| `workers/#` | Yes | Yes |
+
+## Test with mosquitto
+
+Replace `YOUR-CLUSTER`, `YOUR-USERNAME`, and `YOUR-PASSWORD` with the HiveMQ values.
+
+Subscribe in one terminal:
+
+```bash
+mosquitto_sub \
+  -h YOUR-CLUSTER.s1.YOUR-REGION.hivemq.cloud \
+  -p 8883 \
+  -u YOUR-USERNAME \
+  -P YOUR-PASSWORD \
+  --cafile /etc/ssl/cert.pem \
+  -t 'tasks/#'
+```
+
+Publish in another terminal:
+
+```bash
+mosquitto_pub \
+  -h YOUR-CLUSTER.s1.YOUR-REGION.hivemq.cloud \
+  -p 8883 \
+  -u YOUR-USERNAME \
+  -P YOUR-PASSWORD \
+  --cafile /etc/ssl/cert.pem \
+  -t 'tasks/impl/test-repo' \
+  -m '{"task_id":"smoke-test","kind":"impl"}'
+```
+
+The subscriber should receive the JSON message.
+
+## Environment Variables
+
+Export these variables before running the worker:
+
+```bash
+export AI_SWARM_MQTT_BROKER_URL='mqtts://YOUR-CLUSTER.s1.YOUR-REGION.hivemq.cloud:8883'
+export AI_SWARM_MQTT_USERNAME='YOUR-USERNAME'
+export AI_SWARM_MQTT_PASSWORD='YOUR-PASSWORD'
+```
+
+Use equivalent Cloudflare Worker secrets for the bridge:
+
+- `MQTT_BROKER_URL`
+- `MQTT_USERNAME`
+- `MQTT_PASSWORD`
+
+## Troubleshooting
+
+### Connection Refused
+
+Cause: Username or password is incorrect, disabled, or not assigned to the cluster.
+
+Fix:
+
+- Recreate the credential in **Access Management → Credentials**.
+- Confirm the exact username and password are used by the worker and bridge.
+- Confirm the broker hostname and port are correct.
+
+### TLS Errors
+
+Cause: The client cannot find a CA certificate bundle or is connecting without TLS.
+
+Fix:
+
+- Use port `8883`.
+- Use `mqtts://` in application configuration.
+- For `mosquitto_sub` and `mosquitto_pub`, pass `--cafile /etc/ssl/cert.pem`.
+- On systems without `/etc/ssl/cert.pem`, use the platform CA bundle path.
+
+### ACL Denied
+
+Cause: The credential does not have topic permissions for the requested publish or subscribe.
+
+Fix:
+
+- Confirm ACLs include `tasks/#` with subscribe and publish.
+- Confirm ACLs include `workers/#` with subscribe and publish.
+- Retry the `mosquitto_sub` and `mosquitto_pub` test commands.

--- a/infra/tailscale-setup.md
+++ b/infra/tailscale-setup.md
@@ -1,3 +1,86 @@
 # Tailscale Setup
 
-> Placeholder — Tailscale network setup instructions to be added.
+Tailscale is optional for the MVP. HiveMQ Cloud does not require it because workers connect outbound to the managed MQTT broker over TLS.
+
+Use Tailscale only if you want private machine-to-machine access now, or if you later self-host the MQTT broker.
+
+## Install Tailscale
+
+Install Tailscale on each worker machine:
+
+```bash
+curl -fsSL https://tailscale.com/install.sh | sh
+```
+
+On macOS, install from https://tailscale.com/download/mac or use Homebrew:
+
+```bash
+brew install --cask tailscale
+```
+
+## Create a Tailnet
+
+1. Sign in at https://login.tailscale.com/.
+2. Create a new tailnet or use an existing organization tailnet.
+3. Confirm the admin console is accessible.
+
+## Invite Worker Machines
+
+On each worker machine, authenticate with the tailnet:
+
+```bash
+sudo tailscale up
+```
+
+For unattended servers, use an auth key from the Tailscale admin console:
+
+```bash
+sudo tailscale up --auth-key tskey-auth-REPLACE_ME
+```
+
+Confirm each worker appears in the Tailscale admin console.
+
+## ACL Tag
+
+Use the tag `tag:ai-worker` for worker machines.
+
+In the Tailscale admin console:
+
+1. Open **Access controls**.
+2. Add `tag:ai-worker` to `tagOwners`.
+3. Apply the tag to worker machines.
+
+Example ACL fragment:
+
+```json
+{
+  "tagOwners": {
+    "tag:ai-worker": ["autogroup:admin"]
+  },
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["tag:ai-worker"],
+      "dst": ["*:*"]
+    }
+  ]
+}
+```
+
+Restrict `dst` further when you know the exact private services the workers need.
+
+## Future Self-hosted MQTT
+
+If AI Swarm later moves from HiveMQ Cloud to a self-hosted MQTT broker, place the broker inside the tailnet.
+
+Recommended shape:
+
+- Broker runs on a tailnet machine named `broker-machine`.
+- Workers connect outbound through Tailscale.
+- Broker URL becomes:
+
+```text
+mqtts://broker-machine:8883
+```
+
+Keep TLS enabled even inside the tailnet so credentials and messages are encrypted end to end.

--- a/infra/worker-deployment.md
+++ b/infra/worker-deployment.md
@@ -1,0 +1,185 @@
+# Worker Daemon Deployment
+
+This guide installs and runs an AI Swarm worker daemon on a developer machine or server.
+
+## Prerequisites
+
+- Python 3.11+
+- uv
+- GitHub CLI (`gh`) logged in
+- Claude CLI logged in
+- Git
+
+Install uv:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Verify GitHub authentication:
+
+```bash
+gh auth status
+```
+
+Verify Claude CLI authentication:
+
+```bash
+claude --version
+```
+
+## Installation
+
+```bash
+git clone https://github.com/nurockplayer/ai-swarm.git
+cd ai-swarm/worker
+uv sync
+```
+
+## Config Setup
+
+```bash
+mkdir -p ~/.ai-swarm
+cat > ~/.ai-swarm/.env << 'EOF'
+AI_SWARM_MQTT_BROKER_URL=mqtts://YOUR-CLUSTER.hivemq.cloud:8883
+AI_SWARM_MQTT_USERNAME=your-username
+AI_SWARM_MQTT_PASSWORD=your-password
+AI_SWARM_WORKER_ID=my-laptop-worker
+EOF
+source ~/.ai-swarm/.env
+```
+
+## Start
+
+```bash
+cd ai-swarm/worker
+uv run worker start
+```
+
+## macOS launchd
+
+Create `~/Library/LaunchAgents/com.ai-swarm.worker.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.ai-swarm.worker</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/YOUR-USER/.local/bin/uv</string>
+    <string>run</string>
+    <string>worker</string>
+    <string>start</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/YOUR-USER/ai-swarm/worker</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>AI_SWARM_MQTT_BROKER_URL</key>
+    <string>mqtts://YOUR-CLUSTER.hivemq.cloud:8883</string>
+    <key>AI_SWARM_MQTT_USERNAME</key>
+    <string>your-username</string>
+    <key>AI_SWARM_MQTT_PASSWORD</key>
+    <string>your-password</string>
+    <key>AI_SWARM_WORKER_ID</key>
+    <string>my-laptop-worker</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>/tmp/ai-swarm-worker.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/ai-swarm-worker.err</string>
+</dict>
+</plist>
+```
+
+Load and start it:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.ai-swarm.worker.plist
+launchctl start com.ai-swarm.worker
+```
+
+## Linux systemd
+
+Create `/etc/systemd/system/ai-swarm-worker.service`:
+
+```ini
+[Unit]
+Description=AI Swarm Worker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ai-swarm
+WorkingDirectory=/home/ai-swarm/ai-swarm/worker
+Environment=AI_SWARM_MQTT_BROKER_URL=mqtts://YOUR-CLUSTER.hivemq.cloud:8883
+Environment=AI_SWARM_MQTT_USERNAME=your-username
+Environment=AI_SWARM_MQTT_PASSWORD=your-password
+Environment=AI_SWARM_WORKER_ID=linux-worker-1
+ExecStart=/home/ai-swarm/.local/bin/uv run worker start
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start it:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable ai-swarm-worker
+sudo systemctl start ai-swarm-worker
+```
+
+## Verification
+
+Expected worker log line:
+
+```json
+{"ts":"...","level":"INFO","msg":"connected to broker"}
+```
+
+Confirm:
+
+- HiveMQ dashboard shows the worker client online.
+- `gh auth status` succeeds for the worker user.
+- `claude --version` works for the worker user.
+- From the repo root, `./scripts/smoke-test.sh` passes.
+
+## Troubleshooting
+
+### MQTT Connection Failure
+
+Check that `AI_SWARM_MQTT_BROKER_URL` uses `mqtts://` and port `8883`, and that username and password match HiveMQ credentials.
+
+If HiveMQ rejects the connection, confirm the credential is enabled and ACLs allow `tasks/#` and `workers/#`.
+
+### claude CLI Not Found
+
+Check the service user PATH:
+
+```bash
+which claude
+claude --version
+```
+
+For launchd or systemd, use absolute paths or add the CLI install directory to the service environment.
+
+### Git Worktree Failure
+
+Confirm the worker has:
+
+- Write access to its checkout and temporary workspace directory.
+- Git installed and available in PATH.
+- A clean clone with access to the target GitHub repository.
+- `gh auth status` passing for the same OS user that runs the worker.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== AI Swarm E2E Smoke Test Pre-flight ==="
+
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1"
+  local cmd="$2"
+  if eval "$cmd" &>/dev/null; then
+    echo "  ✓ $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  ✗ $name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo ""
+echo "--- Required tools ---"
+check "python3 >= 3.11"  "python3 -c 'import sys; assert sys.version_info >= (3,11)'"
+check "uv"               "uv --version"
+check "git"              "git --version"
+check "gh CLI"           "gh --version"
+check "claude CLI"       "claude --version"
+
+echo ""
+echo "--- Environment variables ---"
+check "AI_SWARM_MQTT_BROKER_URL"  "test -n \"${AI_SWARM_MQTT_BROKER_URL:-}\""
+check "AI_SWARM_MQTT_USERNAME"    "test -n \"${AI_SWARM_MQTT_USERNAME:-}\""
+check "AI_SWARM_MQTT_PASSWORD"    "test -n \"${AI_SWARM_MQTT_PASSWORD:-}\""
+check "GITHUB_TOKEN (gh auth)"    "gh auth status"
+
+echo ""
+echo "--- Worker setup ---"
+check "worker installed (uv sync)"  "test -f worker/pyproject.toml"
+check "pydantic-settings available" "uv --project worker run python -c 'import pydantic_settings'"
+
+echo ""
+echo "--- Results ---"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Fix the above failures before running the E2E test."
+  exit 1
+fi
+
+echo ""
+echo "Pre-flight passed. Run 'worker start' and create a test issue to begin."


### PR DESCRIPTION
## Summary

- Add complete deploy playbook (`infra/hivemq-setup.md`, `infra/cloudflare-deploy.md`, `infra/tailscale-setup.md`, `infra/worker-deployment.md`, `infra/github-webhook-setup.md`)
- Add `scripts/smoke-test.sh` pre-flight checker (validates tools, env vars, gh auth)
- Add `docs/smoke-test-results.md` template for recording E2E test results
- Update `CLAUDE.md` progress table: Tasks 3–6 marked ✅ complete

## Next steps after merge

Run `./scripts/smoke-test.sh` to verify your environment, then follow `infra/worker-deployment.md` to start the worker and trigger the E2E test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)