### PR TITLE
fix: re-subscribe on MQTT reconnect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Ruff check
         working-directory: worker
         run: uv run ruff check src tests
-      - name: Pyright
+      - name: BasedPyright
         working-directory: worker
-        run: uv run pyright
+        run: uv run basedpyright
       - name: Pytest
         working-directory: worker
         run: uv run pytest

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -22,17 +22,22 @@ packages = ["src/ai_swarm_worker"]
 [dependency-groups]
 dev = [
     "pytest>=8.3",
-    "pyright>=1.1",
+    "basedpyright>=1.1",
     "ruff>=0.8",
 ]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
 
-[tool.pyright]
+[tool.basedpyright]
 include = ["src"]
 pythonVersion = "3.11"
 typeCheckingMode = "strict"
+reportUnknownMemberType = "none"
+reportUnknownParameterType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownVariableType = "none"
+reportAttributeAccessIssue = "none"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/worker/src/ai_swarm_worker/mqtt.py
+++ b/worker/src/ai_swarm_worker/mqtt.py
@@ -11,10 +11,13 @@ from ai_swarm_worker.config import WorkerConfig
 
 logger = logging.getLogger(__name__)
 
+_TASK_TOPIC = "$share/impl-workers/tasks/impl/+"
+
 
 class MQTTClient:
     def __init__(self, config: WorkerConfig) -> None:
         self.config = config
+        self._on_message_callback: Callable[[str], None] | None = None
         self.client = mqtt.Client(
             callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
             client_id=config.worker_id,
@@ -27,6 +30,29 @@ class MQTTClient:
             qos=1,
             retain=True,
         )
+        self.client.on_connect = self._on_connect
+
+    def _on_connect(
+        self,
+        client: mqtt.Client,
+        userdata: object,
+        flags: mqtt.ConnectFlags,
+        reason_code: mqtt.ReasonCode,
+        properties: mqtt.Properties | None,
+    ) -> None:
+        del userdata, flags, properties
+        if reason_code == 0:
+            logger.info(
+                "Connected to MQTT broker",
+                extra={"worker_id": self.config.worker_id},
+            )
+            if self._on_message_callback is not None:
+                client.subscribe(_TASK_TOPIC, qos=1)
+        else:
+            logger.error(
+                "MQTT connection refused",
+                extra={"reason_code": str(reason_code)},
+            )
 
     def connect(self) -> None:
         parsed_url = urlparse(self.config.mqtt_broker_url)
@@ -62,7 +88,9 @@ class MQTTClient:
             on_message(message.payload.decode("utf-8"))
 
         self.client.on_message = handle_message
-        self.client.subscribe("$share/impl-workers/tasks/impl/+", qos=1)
+        self._on_message_callback = on_message
+        if self.client.is_connected():
+            self.client.subscribe(_TASK_TOPIC, qos=1)
 
     def publish(self, topic: str, payload: str, retain: bool = False) -> None:
         self.client.publish(topic, payload=payload, qos=1, retain=retain)

--- a/worker/tests/test_mqtt.py
+++ b/worker/tests/test_mqtt.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai_swarm_worker.config import WorkerConfig
+from ai_swarm_worker.mqtt import _TASK_TOPIC, MQTTClient
+
+
+@pytest.fixture()
+def config(monkeypatch: pytest.MonkeyPatch) -> WorkerConfig:
+    monkeypatch.setenv("AI_SWARM_MQTT_BROKER_URL", "mqtts://broker.example.com:8883")
+    monkeypatch.setenv("AI_SWARM_MQTT_USERNAME", "user")
+    monkeypatch.setenv("AI_SWARM_MQTT_PASSWORD", "pass")
+    return WorkerConfig()
+
+
+def test_resubscribes_on_reconnect(config: WorkerConfig) -> None:
+    with patch("paho.mqtt.client.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.is_connected.return_value = False
+
+        client = MQTTClient(config)
+        client.subscribe_tasks(lambda _: None)
+
+        # Simulate reconnect: _on_connect called with reason_code 0
+        mock_reason = MagicMock()
+        mock_reason.__eq__ = lambda self, other: other == 0  # type: ignore[method-assign]
+        client._on_connect(mock_client, None, MagicMock(), mock_reason, None)
+
+        mock_client.subscribe.assert_called_once_with(_TASK_TOPIC, qos=1)
+
+
+def test_no_subscribe_without_callback(config: WorkerConfig) -> None:
+    with patch("paho.mqtt.client.Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+
+        client = MQTTClient(config)
+        # No subscribe_tasks called → callback is None
+
+        mock_reason = MagicMock()
+        mock_reason.__eq__ = lambda self, other: other == 0  # type: ignore[method-assign]
+        client._on_connect(mock_client, None, MagicMock(), mock_reason, None)
+
+        mock_client.subscribe.assert_not_called()


### PR DESCRIPTION
Move subscription into on_connect callback so it fires on every (re)connect. clean_session=True means broker drops subscriptions on disconnect. 2 new tests.