### PR TITLE
docs: deploy playbook — infra/ (Task 8)

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,36 @@
+# Infra Deploy Playbook
+
+This directory contains the deployment runbooks for bringing up AI Swarm in a fresh environment. Follow the files in this order for the main path:
+
+1. [hivemq-setup.md](./hivemq-setup.md) - Create the MQTT broker, credentials, and ACLs.
+2. [cloudflare-deploy.md](./cloudflare-deploy.md) - Deploy the `bridge/` Worker and store the HiveMQ credentials as Cloudflare secrets.
+3. [github-webhook-setup.md](./github-webhook-setup.md) - Point a GitHub repository webhook at the deployed Worker.
+4. [worker-deployment.md](./worker-deployment.md) - Install and start a worker that consumes MQTT tasks.
+
+Optional:
+
+- [tailscale-setup.md](./tailscale-setup.md) - Add private machine access or prepare for a future self-hosted MQTT broker.
+
+## What each file covers
+
+- `hivemq-setup.md`: broker provisioning, credentials, ACLs, and a broker smoke test
+- `cloudflare-deploy.md`: Wrangler login, Worker secrets, deploy, and Worker URL capture
+- `github-webhook-setup.md`: repository webhook creation, delivery checks, and redelivery
+- `worker-deployment.md`: worker install, environment setup, foreground start, and local smoke test
+- `tailscale-setup.md`: optional private networking for operators or future infrastructure changes
+
+## Placeholder policy
+
+All sample values in this directory must stay as placeholders. Use forms like:
+
+- `<YOUR_CLUSTER_ID>`
+- `<YOUR_MQTT_USERNAME>`
+- `<YOUR_MQTT_PASSWORD>`
+- `<YOUR_GITHUB_WEBHOOK_SECRET>`
+- `https://<YOUR_WORKER_SUBDOMAIN>.workers.dev`
+
+Broker URLs should always use this format:
+
+```text
+mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883
+```

--- a/infra/cloudflare-deploy.md
+++ b/infra/cloudflare-deploy.md
@@ -1,109 +1,169 @@
 # Cloudflare Worker Deployment
 
-This guide deploys the AI Swarm bridge as a Cloudflare Worker. The bridge receives GitHub webhook events and publishes tasks to MQTT.
+This guide deploys the `bridge/` service to Cloudflare Workers. It consumes GitHub webhooks and publishes tasks to HiveMQ. Complete this file after [hivemq-setup.md](./hivemq-setup.md), then continue with [github-webhook-setup.md](./github-webhook-setup.md).
 
 ## Prerequisites
 
-- Node.js 18+
-- pnpm
-- A Cloudflare account with Wrangler access
-- A HiveMQ Cloud broker URL, username, and password
-- A GitHub webhook secret
+- Complete [hivemq-setup.md](./hivemq-setup.md)
+- A Cloudflare account: https://dash.cloudflare.com/
+- Node.js and pnpm installed
+- Wrangler install/update guide: https://developers.cloudflare.com/workers/wrangler/install-and-update/
+- Cloudflare Workers CLI docs: https://developers.cloudflare.com/workers/wrangler/
+- The following values ready:
+  - `mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883`
+  - `<YOUR_MQTT_USERNAME>`
+  - `<YOUR_MQTT_PASSWORD>`
+  - `<YOUR_GITHUB_WEBHOOK_SECRET>`
 
-Install Wrangler globally:
+## Step-by-step
 
-```bash
-pnpm add -g wrangler
-```
+1. Open the repo root and install the bridge dependencies.
 
-Log in to Cloudflare:
+   ```bash
+   cd bridge
+   pnpm install
+   ```
 
-```bash
-wrangler login
-```
+2. Authenticate Wrangler with Cloudflare.
 
-## Configure Secrets
+   Login docs: https://developers.cloudflare.com/workers/wrangler/commands/#login
 
-Generate a webhook secret:
+   ```bash
+   pnpm exec wrangler login
+   ```
 
-```bash
-openssl rand -hex 32
-```
+3. Generate a webhook secret that will also be used in GitHub.
 
-From the `bridge/` directory, add the required secrets:
+   ```bash
+   openssl rand -hex 32
+   ```
 
-```bash
-cd bridge
-wrangler secret put GITHUB_WEBHOOK_SECRET
-wrangler secret put MQTT_BROKER_URL
-wrangler secret put MQTT_USERNAME
-wrangler secret put MQTT_PASSWORD
-```
+   Save the output as:
 
-Use the same `GITHUB_WEBHOOK_SECRET` value later when configuring the GitHub webhook.
+   ```text
+   <YOUR_GITHUB_WEBHOOK_SECRET>
+   ```
 
-Use the MQTT broker URL format expected by the bridge, for example:
+4. Set the Worker secret for the GitHub webhook signature.
 
-```text
-mqtts://YOUR-CLUSTER.s1.YOUR-REGION.hivemq.cloud:8883
-```
+   Secret docs: https://developers.cloudflare.com/workers/configuration/secrets/
 
-## Deploy
+   ```bash
+   cd bridge
+   pnpm exec wrangler secret put GITHUB_WEBHOOK_SECRET
+   ```
 
-Deploy the Worker from the `bridge/` directory:
+   When prompted, paste:
 
-```bash
-pnpm deploy
-```
+   ```text
+   <YOUR_GITHUB_WEBHOOK_SECRET>
+   ```
 
-List deployments and copy the Worker URL:
+5. Set the MQTT broker URL secret.
 
-```bash
-wrangler deployments list
-```
+   ```bash
+   cd bridge
+   pnpm exec wrangler secret put MQTT_BROKER_URL
+   ```
 
-The deployed URL should look like:
+   When prompted, paste:
 
-```text
-https://ai-swarm-bridge.YOUR-SUBDOMAIN.workers.dev
-```
+   ```text
+   mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883
+   ```
 
-## GitHub Webhook Setup
+6. Set the MQTT username secret.
 
-In the target GitHub repository:
+   ```bash
+   cd bridge
+   pnpm exec wrangler secret put MQTT_USERNAME
+   ```
 
-1. Open **Settings**.
-2. Open **Webhooks**.
-3. Select **Add webhook**.
-4. Set **Payload URL** to the Cloudflare Worker URL.
-5. Set **Content type** to `application/json`.
-6. Set **Secret** to the same value stored in `GITHUB_WEBHOOK_SECRET`.
-7. Under **Which events would you like to trigger this webhook?**, select **Let me select individual events**.
-8. Enable **Issues** and **Pull requests**.
-9. Keep **Active** checked.
-10. Select **Add webhook**.
+   When prompted, paste:
 
-See [github-webhook-setup.md](github-webhook-setup.md) for detailed webhook testing and redelivery steps.
+   ```text
+   <YOUR_MQTT_USERNAME>
+   ```
+
+7. Set the MQTT password secret.
+
+   ```bash
+   cd bridge
+   pnpm exec wrangler secret put MQTT_PASSWORD
+   ```
+
+   When prompted, paste:
+
+   ```text
+   <YOUR_MQTT_PASSWORD>
+   ```
+
+8. Deploy the Worker.
+
+   ```bash
+   cd bridge
+   pnpm deploy
+   ```
+
+9. List deployments and copy the generated Worker URL.
+
+   ```bash
+   cd bridge
+   pnpm exec wrangler deployments list
+   ```
+
+   Record it as:
+
+   ```text
+   https://<YOUR_WORKER_SUBDOMAIN>.workers.dev
+   ```
+
+## Verification
+
+1. Confirm `pnpm deploy` finishes successfully and prints a deployed Worker name.
+
+2. Confirm `pnpm exec wrangler deployments list` shows the latest deployment.
+
+3. Save the Worker URL as:
+
+   ```text
+   https://<YOUR_WORKER_SUBDOMAIN>.workers.dev
+   ```
+
+4. Continue to [github-webhook-setup.md](./github-webhook-setup.md) with:
+
+   - `https://<YOUR_WORKER_SUBDOMAIN>.workers.dev`
+   - `<YOUR_GITHUB_WEBHOOK_SECRET>`
 
 ## Troubleshooting
 
-### 401 Signature Mismatch
+### `wrangler login` Fails
 
-Cause: GitHub and Cloudflare Worker are using different webhook secret values.
-
-Fix:
-
-- Re-run `wrangler secret put GITHUB_WEBHOOK_SECRET` in `bridge/`.
-- Paste the exact same secret into the GitHub webhook **Secret** field.
-- Redeliver a recent GitHub webhook delivery.
-
-### MQTT Publish Failure
-
-Cause: Broker URL, credentials, or ACLs are incorrect.
+Cause: The browser login flow did not complete or the wrong Cloudflare account was selected.
 
 Fix:
 
-- Confirm `MQTT_BROKER_URL` uses `mqtts://` and port `8883`.
-- Confirm the hostname matches the HiveMQ cluster URL.
-- Confirm `MQTT_USERNAME` and `MQTT_PASSWORD` match HiveMQ Access Management credentials.
-- Confirm HiveMQ ACLs allow publish access to `tasks/#` and `workers/#`.
+- Re-run `pnpm exec wrangler login`.
+- Confirm the browser session lands in the target Cloudflare account.
+- Retry `pnpm exec wrangler deployments list` before deploying again.
+
+### Secret Missing at Deploy Time
+
+Cause: One or more required secrets were never created or were created in a different account.
+
+Fix:
+
+- Re-run `pnpm exec wrangler secret put GITHUB_WEBHOOK_SECRET`.
+- Re-run `pnpm exec wrangler secret put MQTT_BROKER_URL`.
+- Re-run `pnpm exec wrangler secret put MQTT_USERNAME`.
+- Re-run `pnpm exec wrangler secret put MQTT_PASSWORD`.
+
+### MQTT Publish Failure After Deploy
+
+Cause: Cloudflare received the webhook, but the Worker cannot authenticate to HiveMQ.
+
+Fix:
+
+- Confirm `MQTT_BROKER_URL` is exactly `mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883`.
+- Confirm `MQTT_USERNAME` and `MQTT_PASSWORD` match the HiveMQ credential.
+- Re-check the ACLs from [hivemq-setup.md](./hivemq-setup.md).

--- a/infra/github-webhook-setup.md
+++ b/infra/github-webhook-setup.md
@@ -1,127 +1,98 @@
 # GitHub Webhook Setup
 
-This guide connects a GitHub repository to the AI Swarm Cloudflare Worker bridge.
+This guide connects a target GitHub repository to the deployed Cloudflare Worker bridge. Complete this file after [cloudflare-deploy.md](./cloudflare-deploy.md), then continue with [worker-deployment.md](./worker-deployment.md).
 
-The Payload URL comes from the deployed Cloudflare Worker. See [cloudflare-deploy.md](cloudflare-deploy.md) for deployment and URL discovery.
+## Prerequisites
 
-## Required Events
+- Complete [cloudflare-deploy.md](./cloudflare-deploy.md)
+- Admin access to the target GitHub repository
+- GitHub webhook docs:
+  - Create a webhook: https://docs.github.com/en/webhooks/creating-webhooks
+  - View deliveries: https://docs.github.com/webhooks/testing-and-troubleshooting-webhooks/viewing-webhook-deliveries
+  - Redeliver deliveries: https://docs.github.com/enterprise-cloud@latest/webhooks/testing-and-troubleshooting-webhooks/redelivering-webhooks
+- The following values ready:
+  - `https://<YOUR_WORKER_SUBDOMAIN>.workers.dev`
+  - `<YOUR_GITHUB_WEBHOOK_SECRET>`
 
-Select these webhook events:
+## Step-by-step
 
-- **Issues**
-- **Pull requests**
+1. Open the target repository on GitHub.
 
-Issues create implementation tasks. Pull request events create review or follow-up tasks when the routing labels match the AI Swarm configuration.
+2. Go to `Settings` -> `Webhooks` -> `Add webhook`.
 
-## Add the Webhook
+3. Fill `Payload URL` with the deployed Cloudflare Worker URL.
 
-1. Open the target GitHub repository.
-2. Go to **Settings → Webhooks**.
-3. Select **Add webhook**.
-4. Fill in the fields below.
-5. Select **Add webhook**.
+   ```text
+   https://<YOUR_WORKER_SUBDOMAIN>.workers.dev
+   ```
 
-## Field Reference
+4. Set `Content type` to:
 
-### Payload URL
+   ```text
+   application/json
+   ```
 
-Set this to the Cloudflare Worker URL, for example:
+5. Paste the same webhook secret used in Cloudflare.
 
-```text
-https://ai-swarm-bridge.YOUR-SUBDOMAIN.workers.dev
-```
+   ```text
+   <YOUR_GITHUB_WEBHOOK_SECRET>
+   ```
 
-Get this URL with:
+6. Under `Which events would you like to trigger this webhook?`, choose `Let me select individual events`.
 
-```bash
-cd bridge
-wrangler deployments list
-```
+7. Enable these events only:
 
-### Content Type
+   - `Issues`
+   - `Pull requests`
 
-Select:
+8. Keep `Active` checked, then select `Add webhook`.
 
-```text
-application/json
-```
+9. After the webhook is created, open it and inspect `Recent Deliveries`.
 
-The bridge expects JSON webhook payloads.
+10. Confirm the initial `ping` delivery exists and returned a `2xx` response.
 
-### Secret
+11. Trigger a real delivery by adding the `ai-task` label to a test issue in the same repository.
 
-Use the same value stored in the Cloudflare Worker secret:
+12. If the first delivery fails, use `Recent Deliveries` -> `Redeliver` after fixing the bridge secret or MQTT settings.
 
-```bash
-cd bridge
-wrangler secret put GITHUB_WEBHOOK_SECRET
-```
+## Verification
 
-Generate a strong secret with:
+1. The webhook entry is visible under `Settings` -> `Webhooks`.
 
-```bash
-openssl rand -hex 32
-```
+2. `Recent Deliveries` contains a `ping` event with a `2xx` response.
 
-GitHub signs webhook requests with this secret. The bridge rejects requests when the signature does not match.
+3. A labeled issue generates an `issues` webhook delivery with a `2xx` response.
 
-### Events
-
-Choose **Let me select individual events** and enable:
-
-- **Issues**
-- **Pull requests**
-
-### Active
-
-Keep **Active** checked. Inactive webhooks are saved but do not send deliveries.
-
-## Test the Webhook
-
-After creating the webhook:
-
-1. Open **Settings → Webhooks**.
-2. Select the AI Swarm webhook.
-3. Open **Recent Deliveries**.
-4. Confirm GitHub sent a `ping` delivery.
-5. Select the delivery and inspect the response status.
-
-Expected result:
-
-- HTTP status is `2xx`.
-- Response does not show a signature error.
-- Cloudflare Worker logs show the request was received.
-
-Create or update a test issue with the `ai-task` label to trigger an issue delivery.
-
-## Redeliver for Testing
-
-To retry a webhook delivery:
-
-1. Open **Settings → Webhooks**.
-2. Select the AI Swarm webhook.
-3. Open **Recent Deliveries**.
-4. Select a delivery.
-5. Select **Redeliver**.
-
-Use redelivery after changing Cloudflare secrets, MQTT credentials, or bridge code. It lets you test the same payload without creating another GitHub issue.
+4. Continue to [worker-deployment.md](./worker-deployment.md) so a worker is available to consume the published MQTT tasks.
 
 ## Troubleshooting
 
-### 401 Response
+### 401 Signature Mismatch
 
-Cause: The GitHub webhook secret does not match `GITHUB_WEBHOOK_SECRET` in Cloudflare.
+Cause: GitHub and Cloudflare are not using the same `GITHUB_WEBHOOK_SECRET` value.
 
-Fix: Update one side so both values are identical, then redeliver the failed delivery.
+Fix:
 
-### No Deliveries
+- Re-run `pnpm exec wrangler secret put GITHUB_WEBHOOK_SECRET` in `bridge/`.
+- Update the GitHub webhook secret to the exact same value.
+- Use `Redeliver` on the failed delivery.
 
-Cause: The webhook is inactive or the selected event type does not match the GitHub action.
+### No Recent Deliveries
 
-Fix: Confirm **Active** is checked and **Issues** plus **Pull requests** are selected.
+Cause: The webhook is inactive, the repository event did not match, or the webhook was added at the wrong scope.
 
-### MQTT Task Not Published
+Fix:
 
-Cause: The webhook reached Cloudflare, but bridge MQTT configuration failed.
+- Confirm `Active` is enabled.
+- Confirm the webhook was created on the repository that receives the issue or PR activity.
+- Confirm `Issues` and `Pull requests` are both selected.
 
-Fix: Check Cloudflare Worker logs and verify `MQTT_BROKER_URL`, `MQTT_USERNAME`, `MQTT_PASSWORD`, and HiveMQ ACLs.
+### Delivery Is 2xx but No Task Reaches MQTT
+
+Cause: The Worker accepted the webhook but could not publish to HiveMQ.
+
+Fix:
+
+- Re-check `MQTT_BROKER_URL`, `MQTT_USERNAME`, and `MQTT_PASSWORD` in Cloudflare.
+- Re-check the HiveMQ ACLs for `tasks/#` and `workers/#`.
+- Re-deploy the Worker, then redeliver the same webhook.

--- a/infra/hivemq-setup.md
+++ b/infra/hivemq-setup.md
@@ -1,130 +1,145 @@
 # HiveMQ Cloud Setup
 
-This guide creates a HiveMQ Cloud MQTT broker for AI Swarm. The MVP uses HiveMQ Cloud directly, so worker machines do not need public inbound networking.
+This guide creates the managed MQTT broker used by AI Swarm. Complete this file first, then continue with [cloudflare-deploy.md](./cloudflare-deploy.md).
 
-## Create an Account
+## Prerequisites
 
-1. Open https://www.hivemq.com/mqtt-cloud/.
-2. Create or sign in to a HiveMQ Cloud account.
-3. Select the **Serverless** free plan.
+- A HiveMQ Cloud account: https://console.hivemq.cloud/
+- A local shell with `openssl`
+- Optional MQTT CLI tools for verification:
+  - mosquitto clients install guide: https://mosquitto.org/download/
+  - Homebrew example: `brew install mosquitto`
+  - Ubuntu example: `sudo apt-get update && sudo apt-get install -y mosquitto-clients`
+- A secure place to store these placeholders after you create them:
+  - `mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883`
+  - `<YOUR_MQTT_USERNAME>`
+  - `<YOUR_MQTT_PASSWORD>`
 
-## Create a Cluster
+## Step-by-step
 
-1. In HiveMQ Cloud, create a new Serverless cluster.
-2. Select the preferred cloud region.
-3. Wait for the cluster status to become ready.
-4. Copy the cluster URL.
+1. Open the HiveMQ Cloud console.
 
-The URL format is:
+   URL: https://console.hivemq.cloud/
 
-```text
-{cluster-id}.s1.{region}.hivemq.cloud
-```
+2. Sign in, then create a Serverless cluster.
 
-Use port `8883` with TLS for MQTT clients.
+   Product guide: https://docs.hivemq.com/hivemq-cloud/quick-start-guide.html
 
-## Create Credentials
+3. In the cluster creation flow, choose a region and wait until the cluster status is ready.
 
-1. Open the cluster.
-2. Go to **Access Management**.
-3. Open **Credentials**.
-4. Create a new username and password for AI Swarm.
-5. Store the password securely. It will be used by both the Cloudflare bridge and worker daemon.
+4. Open the new cluster and copy the broker hostname.
 
-## Configure ACLs
+   Save it in this format:
 
-In **Access Management**, configure ACL permissions for the AI Swarm credential.
+   ```text
+   mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883
+   ```
 
-Allow subscribe and publish access to:
+5. Create a dedicated username and password for AI Swarm.
 
-```text
-tasks/#
-workers/#
-```
+   In the HiveMQ console, open `Manage Cluster` -> `Access Management` -> `Credentials`, then create:
 
-Required permissions:
+   ```text
+   Username: <YOUR_MQTT_USERNAME>
+   Password: <YOUR_MQTT_PASSWORD>
+   ```
 
-| Topic filter | Subscribe | Publish |
-|---|---:|---:|
-| `tasks/#` | Yes | Yes |
-| `workers/#` | Yes | Yes |
+6. Configure ACLs for that credential.
 
-## Test with mosquitto
+   In `Access Management`, allow both publish and subscribe on:
 
-Replace `YOUR-CLUSTER`, `YOUR-USERNAME`, and `YOUR-PASSWORD` with the HiveMQ values.
+   ```text
+   tasks/#
+   workers/#
+   ```
 
-Subscribe in one terminal:
+   Minimum ACL table:
 
-```bash
-mosquitto_sub \
-  -h YOUR-CLUSTER.s1.YOUR-REGION.hivemq.cloud \
-  -p 8883 \
-  -u YOUR-USERNAME \
-  -P YOUR-PASSWORD \
-  --cafile /etc/ssl/cert.pem \
-  -t 'tasks/#'
-```
+   | Topic filter | Subscribe | Publish |
+   |---|---:|---:|
+   | `tasks/#` | Yes | Yes |
+   | `workers/#` | Yes | Yes |
 
-Publish in another terminal:
+7. Export the values locally so you can reuse them in the next guides.
 
-```bash
-mosquitto_pub \
-  -h YOUR-CLUSTER.s1.YOUR-REGION.hivemq.cloud \
-  -p 8883 \
-  -u YOUR-USERNAME \
-  -P YOUR-PASSWORD \
-  --cafile /etc/ssl/cert.pem \
-  -t 'tasks/impl/test-repo' \
-  -m '{"task_id":"smoke-test","kind":"impl"}'
-```
+   ```bash
+   export AI_SWARM_MQTT_BROKER_URL='mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883'
+   export AI_SWARM_MQTT_USERNAME='<YOUR_MQTT_USERNAME>'
+   export AI_SWARM_MQTT_PASSWORD='<YOUR_MQTT_PASSWORD>'
+   ```
 
-The subscriber should receive the JSON message.
+8. If `mosquitto_sub` and `mosquitto_pub` are installed, run a broker smoke test.
 
-## Environment Variables
+   Terminal A:
 
-Export these variables before running the worker:
+   ```bash
+   mosquitto_sub \
+     -h <YOUR_CLUSTER_ID>.hivemq.cloud \
+     -p 8883 \
+     -u '<YOUR_MQTT_USERNAME>' \
+     -P '<YOUR_MQTT_PASSWORD>' \
+     --cafile /etc/ssl/cert.pem \
+     -t 'tasks/#'
+   ```
 
-```bash
-export AI_SWARM_MQTT_BROKER_URL='mqtts://YOUR-CLUSTER.s1.YOUR-REGION.hivemq.cloud:8883'
-export AI_SWARM_MQTT_USERNAME='YOUR-USERNAME'
-export AI_SWARM_MQTT_PASSWORD='YOUR-PASSWORD'
-```
+   Terminal B:
 
-Use equivalent Cloudflare Worker secrets for the bridge:
+   ```bash
+   mosquitto_pub \
+     -h <YOUR_CLUSTER_ID>.hivemq.cloud \
+     -p 8883 \
+     -u '<YOUR_MQTT_USERNAME>' \
+     -P '<YOUR_MQTT_PASSWORD>' \
+     --cafile /etc/ssl/cert.pem \
+     -t 'tasks/impl/smoke-test' \
+     -m '{"task_id":"smoke-test","type":"implementation"}'
+   ```
 
-- `MQTT_BROKER_URL`
-- `MQTT_USERNAME`
-- `MQTT_PASSWORD`
+## Verification
+
+1. Confirm the HiveMQ dashboard shows the cluster status as ready.
+
+2. Confirm the broker, username, and password are recorded only as placeholders in docs or shell history:
+
+   ```text
+   mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883
+   <YOUR_MQTT_USERNAME>
+   <YOUR_MQTT_PASSWORD>
+   ```
+
+3. If you ran the `mosquitto` smoke test, Terminal A should receive the JSON payload published from Terminal B.
+
+4. Continue to [cloudflare-deploy.md](./cloudflare-deploy.md) with the same three values.
 
 ## Troubleshooting
 
 ### Connection Refused
 
-Cause: Username or password is incorrect, disabled, or not assigned to the cluster.
+Cause: The username or password is wrong, disabled, or attached to a different cluster.
 
 Fix:
 
-- Recreate the credential in **Access Management → Credentials**.
-- Confirm the exact username and password are used by the worker and bridge.
-- Confirm the broker hostname and port are correct.
+- Recreate the credential in `Access Management` -> `Credentials`.
+- Re-export `AI_SWARM_MQTT_USERNAME` and `AI_SWARM_MQTT_PASSWORD`.
+- Re-run the `mosquitto_sub` and `mosquitto_pub` commands.
 
-### TLS Errors
+### TLS or Certificate Error
 
-Cause: The client cannot find a CA certificate bundle or is connecting without TLS.
+Cause: The client is not using TLS, is using the wrong port, or cannot find a CA bundle.
 
 Fix:
 
-- Use port `8883`.
-- Use `mqtts://` in application configuration.
-- For `mosquitto_sub` and `mosquitto_pub`, pass `--cafile /etc/ssl/cert.pem`.
-- On systems without `/etc/ssl/cert.pem`, use the platform CA bundle path.
+- Use port `8883` only.
+- Use `mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883` in application config.
+- Pass `--cafile /etc/ssl/cert.pem` to `mosquitto_*`.
+- If `/etc/ssl/cert.pem` does not exist on your OS, use the platform CA bundle path instead.
 
 ### ACL Denied
 
-Cause: The credential does not have topic permissions for the requested publish or subscribe.
+Cause: The credential can connect but does not have topic permissions.
 
 Fix:
 
-- Confirm ACLs include `tasks/#` with subscribe and publish.
-- Confirm ACLs include `workers/#` with subscribe and publish.
-- Retry the `mosquitto_sub` and `mosquitto_pub` test commands.
+- Confirm both publish and subscribe are enabled for `tasks/#`.
+- Confirm both publish and subscribe are enabled for `workers/#`.
+- Save ACL changes, then repeat the smoke test.

--- a/infra/tailscale-setup.md
+++ b/infra/tailscale-setup.md
@@ -1,86 +1,129 @@
 # Tailscale Setup
 
-Tailscale is optional for the MVP. HiveMQ Cloud does not require it because workers connect outbound to the managed MQTT broker over TLS.
+Tailscale is optional for the current MVP because workers connect outbound to HiveMQ Cloud over TLS. Use this guide if you want private operator access to worker machines now, or if you plan to move MQTT to a self-hosted broker later.
 
-Use Tailscale only if you want private machine-to-machine access now, or if you later self-host the MQTT broker.
+## Prerequisites
 
-## Install Tailscale
+- A Tailscale account: https://login.tailscale.com/
+- Tailscale install docs:
+  - Linux: https://tailscale.com/docs/install/linux
+  - macOS: https://tailscale.com/download/mac
+- Auth key docs: https://tailscale.com/docs/features/access-control/auth-keys
+- A machine that will run the AI Swarm worker
+- Optional placeholder if you use unattended setup:
+  - `<YOUR_TAILSCALE_AUTH_KEY>`
 
-Install Tailscale on each worker machine:
+## Step-by-step
 
-```bash
-curl -fsSL https://tailscale.com/install.sh | sh
-```
+1. Create or sign in to a tailnet.
 
-On macOS, install from https://tailscale.com/download/mac or use Homebrew:
+   Admin console:
 
-```bash
-brew install --cask tailscale
-```
+   ```text
+   https://login.tailscale.com/admin
+   ```
 
-## Create a Tailnet
+2. Install Tailscale on the worker machine.
 
-1. Sign in at https://login.tailscale.com/.
-2. Create a new tailnet or use an existing organization tailnet.
-3. Confirm the admin console is accessible.
+   Ubuntu or Debian:
 
-## Invite Worker Machines
+   ```bash
+   curl -fsSL https://tailscale.com/install.sh | sh
+   ```
 
-On each worker machine, authenticate with the tailnet:
+   macOS with Homebrew:
 
-```bash
-sudo tailscale up
-```
+   ```bash
+   brew install --cask tailscale
+   ```
 
-For unattended servers, use an auth key from the Tailscale admin console:
+3. Start the Tailscale client on the worker machine.
 
-```bash
-sudo tailscale up --auth-key tskey-auth-REPLACE_ME
-```
+   Linux:
 
-Confirm each worker appears in the Tailscale admin console.
+   ```bash
+   sudo tailscale up
+   ```
 
-## ACL Tag
+   For unattended servers, use an auth key instead:
 
-Use the tag `tag:ai-worker` for worker machines.
+   ```bash
+   sudo tailscale up --auth-key='<YOUR_TAILSCALE_AUTH_KEY>'
+   ```
 
-In the Tailscale admin console:
+4. In the Tailscale admin console, confirm the worker machine appears in the machine list.
 
-1. Open **Access controls**.
-2. Add `tag:ai-worker` to `tagOwners`.
-3. Apply the tag to worker machines.
+5. Create a worker tag policy if you want to separate AI Swarm nodes from personal devices.
 
-Example ACL fragment:
+   Open `Access controls`, then add a policy fragment like this:
 
-```json
-{
-  "tagOwners": {
-    "tag:ai-worker": ["autogroup:admin"]
-  },
-  "acls": [
-    {
-      "action": "accept",
-      "src": ["tag:ai-worker"],
-      "dst": ["*:*"]
-    }
-  ]
-}
-```
+   ```json
+   {
+     "tagOwners": {
+       "tag:ai-worker": ["autogroup:admin"]
+     },
+     "acls": [
+       {
+         "action": "accept",
+         "src": ["tag:ai-worker"],
+         "dst": ["*:*"]
+       }
+     ]
+   }
+   ```
 
-Restrict `dst` further when you know the exact private services the workers need.
+6. Apply the `tag:ai-worker` tag to AI Swarm worker machines if your tailnet policy requires it.
 
-## Future Self-hosted MQTT
+7. If you later self-host MQTT inside Tailscale, update the broker value used by AI Swarm to the internal hostname instead of HiveMQ Cloud.
 
-If AI Swarm later moves from HiveMQ Cloud to a self-hosted MQTT broker, place the broker inside the tailnet.
+   Example future format:
 
-Recommended shape:
+   ```text
+   mqtts://<YOUR_TAILNET_BROKER_HOST>:8883
+   ```
 
-- Broker runs on a tailnet machine named `broker-machine`.
-- Workers connect outbound through Tailscale.
-- Broker URL becomes:
+## Verification
 
-```text
-mqtts://broker-machine:8883
-```
+1. The worker machine shows as connected in the Tailscale admin console.
 
-Keep TLS enabled even inside the tailnet so credentials and messages are encrypted end to end.
+2. `tailscale status` lists the machine and shows an assigned tailnet IP.
+
+   ```bash
+   tailscale status
+   ```
+
+3. If you use tagging, the machine shows the `tag:ai-worker` tag in the admin console.
+
+4. If you do not need private operator access, you can skip this file and continue with [worker-deployment.md](./worker-deployment.md).
+
+## Troubleshooting
+
+### `tailscale up` Requires Browser Login on a Headless Server
+
+Cause: Interactive login was used on a machine without a browser session.
+
+Fix:
+
+- Generate an auth key in the Tailscale admin console.
+- Re-run `sudo tailscale up --auth-key='<YOUR_TAILSCALE_AUTH_KEY>'`.
+- Revoke the key after provisioning if it is one-off.
+
+### Machine Appears but Cannot Reach Other Tailnet Nodes
+
+Cause: ACLs or tag policies block traffic.
+
+Fix:
+
+- Review the policy in `Access controls`.
+- Confirm the node has the expected tag, such as `tag:ai-worker`.
+- Temporarily broaden the ACL rule to verify policy is the blocker, then tighten it again.
+
+### Auth Key Rejected
+
+Cause: The auth key expired, was revoked, or was pasted incorrectly.
+
+Fix:
+
+- Generate a new auth key.
+- Copy it again as `<YOUR_TAILSCALE_AUTH_KEY>`.
+- Re-run `sudo tailscale up --auth-key='<YOUR_TAILSCALE_AUTH_KEY>'`.

--- a/infra/worker-deployment.md
+++ b/infra/worker-deployment.md
@@ -1,185 +1,213 @@
 # Worker Daemon Deployment
 
-This guide installs and runs an AI Swarm worker daemon on a developer machine or server.
+This guide installs and runs an AI Swarm worker that consumes MQTT tasks. Complete this file after [github-webhook-setup.md](./github-webhook-setup.md).
 
 ## Prerequisites
 
+- Complete [hivemq-setup.md](./hivemq-setup.md), [cloudflare-deploy.md](./cloudflare-deploy.md), and [github-webhook-setup.md](./github-webhook-setup.md)
 - Python 3.11+
-- uv
-- GitHub CLI (`gh`) logged in
-- Claude CLI logged in
 - Git
+- `uv`
+- GitHub CLI (`gh`) authenticated for the same OS user that will run the worker
+- Claude CLI installed for the same OS user that will run the worker
+- The AI Swarm repository URL and a writable checkout directory
+- The following values ready:
+  - `mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883`
+  - `<YOUR_MQTT_USERNAME>`
+  - `<YOUR_MQTT_PASSWORD>`
+  - `<YOUR_WORKER_ID>`
 
-Install uv:
+## Step-by-step
 
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
+1. Install `uv` if it is not already available.
 
-Verify GitHub authentication:
+   Install guide: https://docs.astral.sh/uv/getting-started/installation/
 
-```bash
-gh auth status
-```
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
 
-Verify Claude CLI authentication:
+2. Verify the required CLIs for the worker user.
 
-```bash
-claude --version
-```
+   ```bash
+   python3 --version
+   uv --version
+   git --version
+   gh auth status
+   claude --version
+   ```
 
-## Installation
+3. Clone the repository into a stable path and install Python dependencies.
 
-```bash
-git clone https://github.com/nurockplayer/ai-swarm.git
-cd ai-swarm/worker
-uv sync
-```
+   ```bash
+   git clone https://github.com/nurockplayer/ai-swarm.git ~/ai-swarm
+   cd ~/ai-swarm/worker
+   uv sync
+   ```
 
-## Config Setup
+4. Create a local environment file for the worker.
 
-```bash
-mkdir -p ~/.ai-swarm
-cat > ~/.ai-swarm/.env << 'EOF'
-AI_SWARM_MQTT_BROKER_URL=mqtts://YOUR-CLUSTER.hivemq.cloud:8883
-AI_SWARM_MQTT_USERNAME=your-username
-AI_SWARM_MQTT_PASSWORD=your-password
-AI_SWARM_WORKER_ID=my-laptop-worker
-EOF
-source ~/.ai-swarm/.env
-```
+   ```bash
+   mkdir -p ~/.ai-swarm
+   cat > ~/.ai-swarm/.env <<'EOF'
+   export AI_SWARM_MQTT_BROKER_URL='mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883'
+   export AI_SWARM_MQTT_USERNAME='<YOUR_MQTT_USERNAME>'
+   export AI_SWARM_MQTT_PASSWORD='<YOUR_MQTT_PASSWORD>'
+   export AI_SWARM_WORKER_ID='<YOUR_WORKER_ID>'
+   EOF
+   ```
 
-## Start
+5. Load the worker environment into the current shell.
 
-```bash
-cd ai-swarm/worker
-uv run worker start
-```
+   ```bash
+   set -a
+   source ~/.ai-swarm/.env
+   set +a
+   ```
 
-## macOS launchd
+6. Start the worker in the foreground for the first boot.
 
-Create `~/Library/LaunchAgents/com.ai-swarm.worker.plist`:
+   ```bash
+   cd ~/ai-swarm/worker
+   uv run worker start
+   ```
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>com.ai-swarm.worker</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/Users/YOUR-USER/.local/bin/uv</string>
-    <string>run</string>
-    <string>worker</string>
-    <string>start</string>
-  </array>
-  <key>WorkingDirectory</key>
-  <string>/Users/YOUR-USER/ai-swarm/worker</string>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>AI_SWARM_MQTT_BROKER_URL</key>
-    <string>mqtts://YOUR-CLUSTER.hivemq.cloud:8883</string>
-    <key>AI_SWARM_MQTT_USERNAME</key>
-    <string>your-username</string>
-    <key>AI_SWARM_MQTT_PASSWORD</key>
-    <string>your-password</string>
-    <key>AI_SWARM_WORKER_ID</key>
-    <string>my-laptop-worker</string>
-  </dict>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-  <key>StandardOutPath</key>
-  <string>/tmp/ai-swarm-worker.log</string>
-  <key>StandardErrorPath</key>
-  <string>/tmp/ai-swarm-worker.err</string>
-</dict>
-</plist>
-```
+7. In a second terminal, run the local pre-flight smoke test from the repo root.
 
-Load and start it:
+   ```bash
+   cd ~/ai-swarm
+   set -a
+   source ~/.ai-swarm/.env
+   set +a
+   ./scripts/smoke-test.sh
+   ```
 
-```bash
-launchctl load ~/Library/LaunchAgents/com.ai-swarm.worker.plist
-launchctl start com.ai-swarm.worker
-```
+8. Optional: install the worker as a background service after the foreground test succeeds.
 
-## Linux systemd
+   macOS `launchd` example:
 
-Create `/etc/systemd/system/ai-swarm-worker.service`:
+   ```xml
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+     "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+   <dict>
+     <key>Label</key>
+     <string>com.ai-swarm.worker</string>
+     <key>ProgramArguments</key>
+     <array>
+       <string>/Users/<YOUR_MACOS_USER>/.local/bin/uv</string>
+       <string>run</string>
+       <string>worker</string>
+       <string>start</string>
+     </array>
+     <key>WorkingDirectory</key>
+     <string>/Users/<YOUR_MACOS_USER>/ai-swarm/worker</string>
+     <key>EnvironmentVariables</key>
+     <dict>
+       <key>AI_SWARM_MQTT_BROKER_URL</key>
+       <string>mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883</string>
+       <key>AI_SWARM_MQTT_USERNAME</key>
+       <string><YOUR_MQTT_USERNAME></string>
+       <key>AI_SWARM_MQTT_PASSWORD</key>
+       <string><YOUR_MQTT_PASSWORD></string>
+       <key>AI_SWARM_WORKER_ID</key>
+       <string><YOUR_WORKER_ID></string>
+     </dict>
+     <key>RunAtLoad</key>
+     <true/>
+     <key>KeepAlive</key>
+     <true/>
+     <key>StandardOutPath</key>
+     <string>/tmp/ai-swarm-worker.log</string>
+     <key>StandardErrorPath</key>
+     <string>/tmp/ai-swarm-worker.err</string>
+   </dict>
+   </plist>
+   ```
 
-```ini
-[Unit]
-Description=AI Swarm Worker
-After=network-online.target
-Wants=network-online.target
+   Load it:
 
-[Service]
-Type=simple
-User=ai-swarm
-WorkingDirectory=/home/ai-swarm/ai-swarm/worker
-Environment=AI_SWARM_MQTT_BROKER_URL=mqtts://YOUR-CLUSTER.hivemq.cloud:8883
-Environment=AI_SWARM_MQTT_USERNAME=your-username
-Environment=AI_SWARM_MQTT_PASSWORD=your-password
-Environment=AI_SWARM_WORKER_ID=linux-worker-1
-ExecStart=/home/ai-swarm/.local/bin/uv run worker start
-Restart=always
-RestartSec=5
+   ```bash
+   launchctl unload ~/Library/LaunchAgents/com.ai-swarm.worker.plist 2>/dev/null || true
+   launchctl load ~/Library/LaunchAgents/com.ai-swarm.worker.plist
+   launchctl start com.ai-swarm.worker
+   ```
 
-[Install]
-WantedBy=multi-user.target
-```
+   Linux `systemd` example:
 
-Enable and start it:
+   ```ini
+   [Unit]
+   Description=AI Swarm Worker
+   After=network-online.target
+   Wants=network-online.target
 
-```bash
-sudo systemctl daemon-reload
-sudo systemctl enable ai-swarm-worker
-sudo systemctl start ai-swarm-worker
-```
+   [Service]
+   Type=simple
+   User=<YOUR_LINUX_USER>
+   WorkingDirectory=/home/<YOUR_LINUX_USER>/ai-swarm/worker
+   Environment=AI_SWARM_MQTT_BROKER_URL=mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883
+   Environment=AI_SWARM_MQTT_USERNAME=<YOUR_MQTT_USERNAME>
+   Environment=AI_SWARM_MQTT_PASSWORD=<YOUR_MQTT_PASSWORD>
+   Environment=AI_SWARM_WORKER_ID=<YOUR_WORKER_ID>
+   ExecStart=/home/<YOUR_LINUX_USER>/.local/bin/uv run worker start
+   Restart=always
+   RestartSec=5
+
+   [Install]
+   WantedBy=multi-user.target
+   ```
+
+   Enable it:
+
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable ai-swarm-worker
+   sudo systemctl start ai-swarm-worker
+   ```
 
 ## Verification
 
-Expected worker log line:
+1. The worker process starts without exiting immediately.
 
-```json
-{"ts":"...","level":"INFO","msg":"connected to broker"}
-```
+2. The worker log shows a successful broker connection, for example:
 
-Confirm:
+   ```json
+   {"ts":"<YOUR_TIMESTAMP>","level":"INFO","msg":"connected to broker"}
+   ```
 
-- HiveMQ dashboard shows the worker client online.
-- `gh auth status` succeeds for the worker user.
-- `claude --version` works for the worker user.
-- From the repo root, `./scripts/smoke-test.sh` passes.
+3. `./scripts/smoke-test.sh` passes all local pre-flight checks.
+
+4. After you label a GitHub issue with `ai-task`, the worker remains connected and is ready to consume the task.
 
 ## Troubleshooting
 
 ### MQTT Connection Failure
 
-Check that `AI_SWARM_MQTT_BROKER_URL` uses `mqtts://` and port `8883`, and that username and password match HiveMQ credentials.
+Cause: The worker cannot authenticate to HiveMQ or the broker URL is malformed.
 
-If HiveMQ rejects the connection, confirm the credential is enabled and ACLs allow `tasks/#` and `workers/#`.
+Fix:
 
-### claude CLI Not Found
+- Confirm `AI_SWARM_MQTT_BROKER_URL` is exactly `mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883`.
+- Confirm `AI_SWARM_MQTT_USERNAME` and `AI_SWARM_MQTT_PASSWORD` match HiveMQ.
+- Re-check HiveMQ ACLs for `tasks/#` and `workers/#`.
 
-Check the service user PATH:
+### `claude` or `gh` Not Found in Service Mode
 
-```bash
-which claude
-claude --version
-```
+Cause: The background service user does not inherit the same PATH as your interactive shell.
 
-For launchd or systemd, use absolute paths or add the CLI install directory to the service environment.
+Fix:
 
-### Git Worktree Failure
+- Run `gh auth status` and `claude --version` as the service user.
+- Use absolute paths in `launchd` or `systemd`.
+- Restart the service after updating the PATH or service file.
 
-Confirm the worker has:
+### Smoke Test Fails Before MQTT
 
-- Write access to its checkout and temporary workspace directory.
-- Git installed and available in PATH.
-- A clean clone with access to the target GitHub repository.
-- `gh auth status` passing for the same OS user that runs the worker.
+Cause: The worker shell did not export environment variables, or dependencies were not installed.
+
+Fix:
+
+- Re-run `uv sync` inside `~/ai-swarm/worker`.
+- Re-run `set -a; source ~/.ai-swarm/.env; set +a`.
+- Re-run `./scripts/smoke-test.sh` from the repo root.


### PR DESCRIPTION
## Summary
- `infra/README.md`: added a one-page overview, reading order, and placeholder policy for the deploy playbook
- `infra/hivemq-setup.md`: rebuilt the broker setup guide with prerequisites, numbered steps, verification, ACL guidance, and broker smoke test commands
- `infra/cloudflare-deploy.md`: rebuilt the Cloudflare Worker deploy guide with Wrangler setup, explicit secret creation steps, deployment, and handoff to webhook setup
- `infra/github-webhook-setup.md`: rebuilt the GitHub webhook guide with repository settings flow, delivery verification, and redelivery workflow
- `infra/worker-deployment.md`: rebuilt the worker install/run guide with fixed repo pathing, env setup, pre-flight smoke test, and service examples
- `infra/tailscale-setup.md`: expanded the optional networking guide to match the same playbook format and troubleshooting standard

## Acceptance Criteria
- [x] Fresh-environment path is documented end-to-end with prerequisites, numbered steps, direct URLs, verification sections, and a continuous `hivemq -> cloudflare -> github-webhook -> worker` flow
- [x] Every infra runbook ends with a `## Troubleshooting` section covering common failure cases with causes and fixes
- [x] All sample credentials, broker URLs, and deployment values use placeholders only, including the required broker format `mqtts://<YOUR_CLUSTER_ID>.hivemq.cloud:8883`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured infrastructure deployment guides with improved step-by-step workflows and clearer prerequisites.
  * Enhanced troubleshooting sections across HiveMQ, Cloudflare, GitHub webhook, Tailscale, and worker deployment documentation.
  * Created centralized deployment runbook index for easier navigation during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->